### PR TITLE
Make RenderPipelineDescriptor::vertexInput a pointer

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -651,7 +651,7 @@ typedef struct WGPURenderPipelineDescriptor {
     WGPUPipelineLayout layout;
     WGPUPipelineStageDescriptor vertexStage;
     WGPUPipelineStageDescriptor const * fragmentStage;
-    WGPUVertexInputDescriptor vertexInput;
+    WGPUVertexInputDescriptor const * vertexInput;
     WGPUPrimitiveTopology primitiveTopology;
     WGPURasterizationStateDescriptor const * rasterizationState;
     uint32_t sampleCount;


### PR DESCRIPTION
This part of the descriptor is now optional in WebGPU so it is changed
to be a pointer instead of being by value in the
RenderPipelineDescriptor.