### PR TITLE
webgpu.h: Fix WGPU_WHOLE_SIZE causing linking errors.

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -52,7 +52,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-const uint64_t WGPU_WHOLE_SIZE = 0xffffffffffffffffULL; // UINT64_MAX
+#define WGPU_WHOLE_SIZE (0xffffffffffffffffULL)
 
 typedef uint32_t WGPUFlags;
 


### PR DESCRIPTION
The symbol was not marked as static and would cause linking errors
because it would be defined in multiple translation units. Replace it
with a more traditional C-style #define.

Found by @floooh.