### PR TITLE
Make present modes more Vulkan-like.

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -227,8 +227,9 @@ typedef enum WGPULoadOp {
 } WGPULoadOp;
 
 typedef enum WGPUPresentMode {
-    WGPUPresentMode_NoVSync = 0x00000000,
-    WGPUPresentMode_VSync = 0x00000001,
+    WGPUPresentMode_Immediate = 0x00000000,
+    WGPUPresentMode_Mailbox = 0x00000001,
+    WGPUPresentMode_Fifo = 0x00000002,
     WGPUPresentMode_Force32 = 0x7FFFFFFF
 } WGPUPresentMode;
 


### PR DESCRIPTION
The previous present modes couldn't make the difference between double
and triple buffering. This also changes the enums to be more Vulkan-like
because the names make more semantic sense.