### PR TITLE
Pass Surface in AdapterDescriptor

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -446,6 +446,7 @@ typedef struct WGPUChainedStruct {
 
 typedef struct WGPUAdapterDescriptor {
     WGPUChainedStruct const * nextInChain;
+    WGPUSurface compatibleSurface;
 } WGPUAdapterDescriptor;
 
 typedef struct WGPUAdapterProperties {


### PR DESCRIPTION
See https://github.com/gfx-rs/wgpu/issues/543 for the original issue.
What we can do is having an optional `GPUSurface` passed at adapter request time, which requires that the presentation to this surface is possible. It could be NULL, which means we aren't interested in presenting.