### PR TITLE
Add WGPU_COPY_STRIDE_UNDEFINED

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -53,6 +53,7 @@
 #include <stdbool.h>
 
 #define WGPU_WHOLE_SIZE (0xffffffffffffffffULL)
+#define WGPU_COPY_STRIDE_UNDEFINED (0xffffffffUL)
 
 typedef uint32_t WGPUFlags;
 


### PR DESCRIPTION
A stride (bytesPerRow or rowsPerImage) of 0 means "IDL 0" and
WGPU_COPY_STRIDE_UNDEFINED means "IDL undefined" for the purposes of
validation:
https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-linear-texture-data

WGPU_COPY_STRIDE_UNDEFINED is 0xFFFF'FFFF which would be invalid anyway
(not aligned for bytesPerRow, too big for rowsPerImage).