### PR TITLE
Add WGPUFeatureName enum and wgpuAdapterGetFeatures

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -444,6 +444,16 @@ typedef enum WGPUBufferUsage {
 } WGPUBufferUsage;
 typedef WGPUFlags WGPUBufferUsageFlags;
 
+typedef enum WGPUFeatureName {
+  WGPUFeatureName_DepthClamping = 0x00000000,
+  WGPUFeatureName_Depth24UnormStencil8 = 0x00000001,
+  WGPUFeatureName_Depth32FloatStencil8 = 0x00000002,
+  WGPUFeatureName_PipelineStatisticsQuery = 0x00000003,
+  WGPUFeatureName_TextureCompressionBC = 0x00000004,
+  WGPUFeatureName_TimestampQuery = 0x00000005,
+  WGPUFeatureName_Force32 = 0x7FFFFFFF
+} WGPUFeatureName;
+
 typedef enum WGPUColorWriteMask {
     WGPUColorWriteMask_None = 0x00000000,
     WGPUColorWriteMask_Red = 0x00000001,
@@ -557,6 +567,8 @@ typedef struct WGPUComputePassDescriptor {
 
 typedef struct WGPUDeviceDescriptor {
     WGPUChainedStruct const * nextInChain;
+    uint32_t nonGuaranteedFeaturesCount;
+    WGPUFeatureName const * nonGuaranteedFeatures;
 } WGPUDeviceDescriptor;
 
 typedef struct WGPUExtent3D {
@@ -881,6 +893,7 @@ typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUDevice device, char const * procN
 
 // Procs of Adapter
 typedef void (*WGPUProcAdapterGetProperties)(WGPUAdapter adapter, WGPUAdapterProperties * properties);
+typedef uint32_t (*WGPUProcAdapterGetFeatures)(WGPUAdapter adapter, WGPUFeatureName * features);
 typedef void (*WGPUProcAdapterRequestDevice)(WGPUAdapter adapter, WGPUDeviceDescriptor const * descriptor, WGPURequestDeviceCallback callback, void * userdata);
 
 // Procs of Buffer
@@ -1022,6 +1035,7 @@ WGPU_EXPORT WGPUProc wgpuGetProcAddress(WGPUDevice device, char const * procName
 
 // Methods of Adapter
 WGPU_EXPORT void wgpuAdapterGetProperties(WGPUAdapter adapter, WGPUAdapterProperties * properties);
+WGPU_EXPORT uint32_t wgpuAdapterGetFeatures(WGPUAdapter adapter, WGPUFeatureName * features);
 WGPU_EXPORT void wgpuAdapterRequestDevice(WGPUAdapter adapter, WGPUDeviceDescriptor const * descriptor, WGPURequestDeviceCallback callback, void * userdata);
 
 // Methods of Buffer


### PR DESCRIPTION
wgpuAdapterGetFeatures when passed nullptr for |features| returns
the number of features the adapter has. When passed non-null, it
serializes the list of enums of available features into the pointer.

A list of features can then be passed in the WGPUDeviceDescriptor to
request a device with those features enabled.

Fixes #74