### PR TITLE
Add constants to vertex state and fragment state

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1001,6 +1001,8 @@ typedef struct WGPUVertexState {
     WGPUChainedStruct const * nextInChain;
     WGPUShaderModule module;
     char const * entryPoint;
+    uint32_t constantCount;
+    WGPUConstantEntry const * constants;
     uint32_t bufferCount;
     WGPUVertexBufferLayout const * buffers;
 } WGPUVertexState;
@@ -1009,6 +1011,8 @@ typedef struct WGPUFragmentState {
     WGPUChainedStruct const * nextInChain;
     WGPUShaderModule module;
     char const * entryPoint;
+    uint32_t constantCount;
+    WGPUConstantEntry const * constants;
     uint32_t targetCount;
     WGPUColorTargetState const * targets;
 } WGPUFragmentState;


### PR DESCRIPTION
Follow up of https://github.com/webgpu-native/webgpu-headers/pull/99

Realized WGPUProgrammableStageDescriptor has no inheritance here as in spec during implementation.
Add the same `constantCount` and `constants` fields to `WGPUVertexState` and `WGPUFragmentState`