### PR TITLE
 Update headers with dawn webgpu_headers_gen @98f18d

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -231,14 +231,13 @@ typedef enum WGPUErrorType {
 typedef enum WGPUFeatureName {
     WGPUFeatureName_Undefined = 0x00000000,
     WGPUFeatureName_DepthClipControl = 0x00000001,
-    WGPUFeatureName_Depth24UnormStencil8 = 0x00000002,
-    WGPUFeatureName_Depth32FloatStencil8 = 0x00000003,
-    WGPUFeatureName_TimestampQuery = 0x00000004,
-    WGPUFeatureName_PipelineStatisticsQuery = 0x00000005,
-    WGPUFeatureName_TextureCompressionBC = 0x00000006,
-    WGPUFeatureName_TextureCompressionETC2 = 0x00000007,
-    WGPUFeatureName_TextureCompressionASTC = 0x00000008,
-    WGPUFeatureName_IndirectFirstInstance = 0x00000009,
+    WGPUFeatureName_Depth32FloatStencil8 = 0x00000002,
+    WGPUFeatureName_TimestampQuery = 0x00000003,
+    WGPUFeatureName_PipelineStatisticsQuery = 0x00000004,
+    WGPUFeatureName_TextureCompressionBC = 0x00000005,
+    WGPUFeatureName_TextureCompressionETC2 = 0x00000006,
+    WGPUFeatureName_TextureCompressionASTC = 0x00000007,
+    WGPUFeatureName_IndirectFirstInstance = 0x00000008,
     WGPUFeatureName_Force32 = 0x7FFFFFFF
 } WGPUFeatureName;
 
@@ -354,6 +353,7 @@ typedef enum WGPUSType {
     WGPUSType_SurfaceDescriptorFromWaylandSurface = 0x00000008,
     WGPUSType_SurfaceDescriptorFromAndroidNativeWindow = 0x00000009,
     WGPUSType_SurfaceDescriptorFromXcbWindow = 0x0000000A,
+    WGPUSType_RenderPassDescriptorMaxDrawCount = 0x0000000F,
     WGPUSType_Force32 = 0x7FFFFFFF
 } WGPUSType;
 
@@ -454,61 +454,60 @@ typedef enum WGPUTextureFormat {
     WGPUTextureFormat_Depth16Unorm = 0x00000026,
     WGPUTextureFormat_Depth24Plus = 0x00000027,
     WGPUTextureFormat_Depth24PlusStencil8 = 0x00000028,
-    WGPUTextureFormat_Depth24UnormStencil8 = 0x00000029,
-    WGPUTextureFormat_Depth32Float = 0x0000002A,
-    WGPUTextureFormat_Depth32FloatStencil8 = 0x0000002B,
-    WGPUTextureFormat_BC1RGBAUnorm = 0x0000002C,
-    WGPUTextureFormat_BC1RGBAUnormSrgb = 0x0000002D,
-    WGPUTextureFormat_BC2RGBAUnorm = 0x0000002E,
-    WGPUTextureFormat_BC2RGBAUnormSrgb = 0x0000002F,
-    WGPUTextureFormat_BC3RGBAUnorm = 0x00000030,
-    WGPUTextureFormat_BC3RGBAUnormSrgb = 0x00000031,
-    WGPUTextureFormat_BC4RUnorm = 0x00000032,
-    WGPUTextureFormat_BC4RSnorm = 0x00000033,
-    WGPUTextureFormat_BC5RGUnorm = 0x00000034,
-    WGPUTextureFormat_BC5RGSnorm = 0x00000035,
-    WGPUTextureFormat_BC6HRGBUfloat = 0x00000036,
-    WGPUTextureFormat_BC6HRGBFloat = 0x00000037,
-    WGPUTextureFormat_BC7RGBAUnorm = 0x00000038,
-    WGPUTextureFormat_BC7RGBAUnormSrgb = 0x00000039,
-    WGPUTextureFormat_ETC2RGB8Unorm = 0x0000003A,
-    WGPUTextureFormat_ETC2RGB8UnormSrgb = 0x0000003B,
-    WGPUTextureFormat_ETC2RGB8A1Unorm = 0x0000003C,
-    WGPUTextureFormat_ETC2RGB8A1UnormSrgb = 0x0000003D,
-    WGPUTextureFormat_ETC2RGBA8Unorm = 0x0000003E,
-    WGPUTextureFormat_ETC2RGBA8UnormSrgb = 0x0000003F,
-    WGPUTextureFormat_EACR11Unorm = 0x00000040,
-    WGPUTextureFormat_EACR11Snorm = 0x00000041,
-    WGPUTextureFormat_EACRG11Unorm = 0x00000042,
-    WGPUTextureFormat_EACRG11Snorm = 0x00000043,
-    WGPUTextureFormat_ASTC4x4Unorm = 0x00000044,
-    WGPUTextureFormat_ASTC4x4UnormSrgb = 0x00000045,
-    WGPUTextureFormat_ASTC5x4Unorm = 0x00000046,
-    WGPUTextureFormat_ASTC5x4UnormSrgb = 0x00000047,
-    WGPUTextureFormat_ASTC5x5Unorm = 0x00000048,
-    WGPUTextureFormat_ASTC5x5UnormSrgb = 0x00000049,
-    WGPUTextureFormat_ASTC6x5Unorm = 0x0000004A,
-    WGPUTextureFormat_ASTC6x5UnormSrgb = 0x0000004B,
-    WGPUTextureFormat_ASTC6x6Unorm = 0x0000004C,
-    WGPUTextureFormat_ASTC6x6UnormSrgb = 0x0000004D,
-    WGPUTextureFormat_ASTC8x5Unorm = 0x0000004E,
-    WGPUTextureFormat_ASTC8x5UnormSrgb = 0x0000004F,
-    WGPUTextureFormat_ASTC8x6Unorm = 0x00000050,
-    WGPUTextureFormat_ASTC8x6UnormSrgb = 0x00000051,
-    WGPUTextureFormat_ASTC8x8Unorm = 0x00000052,
-    WGPUTextureFormat_ASTC8x8UnormSrgb = 0x00000053,
-    WGPUTextureFormat_ASTC10x5Unorm = 0x00000054,
-    WGPUTextureFormat_ASTC10x5UnormSrgb = 0x00000055,
-    WGPUTextureFormat_ASTC10x6Unorm = 0x00000056,
-    WGPUTextureFormat_ASTC10x6UnormSrgb = 0x00000057,
-    WGPUTextureFormat_ASTC10x8Unorm = 0x00000058,
-    WGPUTextureFormat_ASTC10x8UnormSrgb = 0x00000059,
-    WGPUTextureFormat_ASTC10x10Unorm = 0x0000005A,
-    WGPUTextureFormat_ASTC10x10UnormSrgb = 0x0000005B,
-    WGPUTextureFormat_ASTC12x10Unorm = 0x0000005C,
-    WGPUTextureFormat_ASTC12x10UnormSrgb = 0x0000005D,
-    WGPUTextureFormat_ASTC12x12Unorm = 0x0000005E,
-    WGPUTextureFormat_ASTC12x12UnormSrgb = 0x0000005F,
+    WGPUTextureFormat_Depth32Float = 0x00000029,
+    WGPUTextureFormat_Depth32FloatStencil8 = 0x0000002A,
+    WGPUTextureFormat_BC1RGBAUnorm = 0x0000002B,
+    WGPUTextureFormat_BC1RGBAUnormSrgb = 0x0000002C,
+    WGPUTextureFormat_BC2RGBAUnorm = 0x0000002D,
+    WGPUTextureFormat_BC2RGBAUnormSrgb = 0x0000002E,
+    WGPUTextureFormat_BC3RGBAUnorm = 0x0000002F,
+    WGPUTextureFormat_BC3RGBAUnormSrgb = 0x00000030,
+    WGPUTextureFormat_BC4RUnorm = 0x00000031,
+    WGPUTextureFormat_BC4RSnorm = 0x00000032,
+    WGPUTextureFormat_BC5RGUnorm = 0x00000033,
+    WGPUTextureFormat_BC5RGSnorm = 0x00000034,
+    WGPUTextureFormat_BC6HRGBUfloat = 0x00000035,
+    WGPUTextureFormat_BC6HRGBFloat = 0x00000036,
+    WGPUTextureFormat_BC7RGBAUnorm = 0x00000037,
+    WGPUTextureFormat_BC7RGBAUnormSrgb = 0x00000038,
+    WGPUTextureFormat_ETC2RGB8Unorm = 0x00000039,
+    WGPUTextureFormat_ETC2RGB8UnormSrgb = 0x0000003A,
+    WGPUTextureFormat_ETC2RGB8A1Unorm = 0x0000003B,
+    WGPUTextureFormat_ETC2RGB8A1UnormSrgb = 0x0000003C,
+    WGPUTextureFormat_ETC2RGBA8Unorm = 0x0000003D,
+    WGPUTextureFormat_ETC2RGBA8UnormSrgb = 0x0000003E,
+    WGPUTextureFormat_EACR11Unorm = 0x0000003F,
+    WGPUTextureFormat_EACR11Snorm = 0x00000040,
+    WGPUTextureFormat_EACRG11Unorm = 0x00000041,
+    WGPUTextureFormat_EACRG11Snorm = 0x00000042,
+    WGPUTextureFormat_ASTC4x4Unorm = 0x00000043,
+    WGPUTextureFormat_ASTC4x4UnormSrgb = 0x00000044,
+    WGPUTextureFormat_ASTC5x4Unorm = 0x00000045,
+    WGPUTextureFormat_ASTC5x4UnormSrgb = 0x00000046,
+    WGPUTextureFormat_ASTC5x5Unorm = 0x00000047,
+    WGPUTextureFormat_ASTC5x5UnormSrgb = 0x00000048,
+    WGPUTextureFormat_ASTC6x5Unorm = 0x00000049,
+    WGPUTextureFormat_ASTC6x5UnormSrgb = 0x0000004A,
+    WGPUTextureFormat_ASTC6x6Unorm = 0x0000004B,
+    WGPUTextureFormat_ASTC6x6UnormSrgb = 0x0000004C,
+    WGPUTextureFormat_ASTC8x5Unorm = 0x0000004D,
+    WGPUTextureFormat_ASTC8x5UnormSrgb = 0x0000004E,
+    WGPUTextureFormat_ASTC8x6Unorm = 0x0000004F,
+    WGPUTextureFormat_ASTC8x6UnormSrgb = 0x00000050,
+    WGPUTextureFormat_ASTC8x8Unorm = 0x00000051,
+    WGPUTextureFormat_ASTC8x8UnormSrgb = 0x00000052,
+    WGPUTextureFormat_ASTC10x5Unorm = 0x00000053,
+    WGPUTextureFormat_ASTC10x5UnormSrgb = 0x00000054,
+    WGPUTextureFormat_ASTC10x6Unorm = 0x00000055,
+    WGPUTextureFormat_ASTC10x6UnormSrgb = 0x00000056,
+    WGPUTextureFormat_ASTC10x8Unorm = 0x00000057,
+    WGPUTextureFormat_ASTC10x8UnormSrgb = 0x00000058,
+    WGPUTextureFormat_ASTC10x10Unorm = 0x00000059,
+    WGPUTextureFormat_ASTC10x10UnormSrgb = 0x0000005A,
+    WGPUTextureFormat_ASTC12x10Unorm = 0x0000005B,
+    WGPUTextureFormat_ASTC12x10UnormSrgb = 0x0000005C,
+    WGPUTextureFormat_ASTC12x12Unorm = 0x0000005D,
+    WGPUTextureFormat_ASTC12x12UnormSrgb = 0x0000005E,
     WGPUTextureFormat_Force32 = 0x7FFFFFFF
 } WGPUTextureFormat;
 
@@ -753,6 +752,8 @@ typedef struct WGPULimits {
     uint32_t maxVertexAttributes;
     uint32_t maxVertexBufferArrayStride;
     uint32_t maxInterStageShaderComponents;
+    uint32_t maxInterStageShaderVariables;
+    uint32_t maxColorAttachments;
     uint32_t maxComputeWorkgroupStorageSize;
     uint32_t maxComputeInvocationsPerWorkgroup;
     uint32_t maxComputeWorkgroupSizeX;
@@ -781,6 +782,7 @@ typedef struct WGPUPipelineLayoutDescriptor {
     WGPUBindGroupLayout const * bindGroupLayouts;
 } WGPUPipelineLayoutDescriptor;
 
+// Can be chained in WGPUPrimitiveState
 typedef struct WGPUPrimitiveDepthClipControl {
     WGPUChainedStruct chain;
     bool unclippedDepth;
@@ -836,6 +838,12 @@ typedef struct WGPURenderPassDepthStencilAttachment {
     bool stencilReadOnly;
 } WGPURenderPassDepthStencilAttachment;
 
+// Can be chained in WGPURenderPassDescriptor
+typedef struct WGPURenderPassDescriptorMaxDrawCount {
+    WGPUChainedStruct chain;
+    uint64_t maxDrawCount;
+} WGPURenderPassDescriptorMaxDrawCount;
+
 typedef struct WGPURenderPassTimestampWrite {
     WGPUQuerySet querySet;
     uint32_t queryIndex;
@@ -875,12 +883,14 @@ typedef struct WGPUShaderModuleCompilationHint {
     WGPUPipelineLayout layout;
 } WGPUShaderModuleCompilationHint;
 
+// Can be chained in WGPUShaderModuleDescriptor
 typedef struct WGPUShaderModuleSPIRVDescriptor {
     WGPUChainedStruct chain;
     uint32_t codeSize;
     uint32_t const * code;
 } WGPUShaderModuleSPIRVDescriptor;
 
+// Can be chained in WGPUShaderModuleDescriptor
 typedef struct WGPUShaderModuleWGSLDescriptor {
     WGPUChainedStruct chain;
     char const * code;
@@ -905,39 +915,46 @@ typedef struct WGPUSurfaceDescriptor {
     char const * label; // nullable
 } WGPUSurfaceDescriptor;
 
+// Can be chained in WGPUSurfaceDescriptor
 typedef struct WGPUSurfaceDescriptorFromAndroidNativeWindow {
     WGPUChainedStruct chain;
     void * window;
 } WGPUSurfaceDescriptorFromAndroidNativeWindow;
 
+// Can be chained in WGPUSurfaceDescriptor
 typedef struct WGPUSurfaceDescriptorFromCanvasHTMLSelector {
     WGPUChainedStruct chain;
     char const * selector;
 } WGPUSurfaceDescriptorFromCanvasHTMLSelector;
 
+// Can be chained in WGPUSurfaceDescriptor
 typedef struct WGPUSurfaceDescriptorFromMetalLayer {
     WGPUChainedStruct chain;
     void * layer;
 } WGPUSurfaceDescriptorFromMetalLayer;
 
+// Can be chained in WGPUSurfaceDescriptor
 typedef struct WGPUSurfaceDescriptorFromWaylandSurface {
     WGPUChainedStruct chain;
     void * display;
     void * surface;
 } WGPUSurfaceDescriptorFromWaylandSurface;
 
+// Can be chained in WGPUSurfaceDescriptor
 typedef struct WGPUSurfaceDescriptorFromWindowsHWND {
     WGPUChainedStruct chain;
     void * hinstance;
     void * hwnd;
 } WGPUSurfaceDescriptorFromWindowsHWND;
 
+// Can be chained in WGPUSurfaceDescriptor
 typedef struct WGPUSurfaceDescriptorFromXcbWindow {
     WGPUChainedStruct chain;
     void * connection;
     uint32_t window;
 } WGPUSurfaceDescriptorFromXcbWindow;
 
+// Can be chained in WGPUSurfaceDescriptor
 typedef struct WGPUSurfaceDescriptorFromXlibWindow {
     WGPUChainedStruct chain;
     void * display;


### PR DESCRIPTION
- Remove `Depth24UnormStencil8` format and feature
- Add `RenderPassDescriptor.maxDrawCount`
- Add `limits.maxInterStageShaderVariables` and `limits.maxColorAttachments`