### PR TITLE
Add backend type to WGPURequestAdapterOptions

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -190,14 +190,15 @@ typedef enum WGPUAddressMode {
 } WGPUAddressMode WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUBackendType {
-    WGPUBackendType_Null = 0x00000000,
-    WGPUBackendType_WebGPU = 0x00000001,
-    WGPUBackendType_D3D11 = 0x00000002,
-    WGPUBackendType_D3D12 = 0x00000003,
-    WGPUBackendType_Metal = 0x00000004,
-    WGPUBackendType_Vulkan = 0x00000005,
-    WGPUBackendType_OpenGL = 0x00000006,
-    WGPUBackendType_OpenGLES = 0x00000007,
+    WGPUBackendType_Undefined = 0x00000000,
+    WGPUBackendType_Null = 0x00000001,
+    WGPUBackendType_WebGPU = 0x00000002,
+    WGPUBackendType_D3D11 = 0x00000003,
+    WGPUBackendType_D3D12 = 0x00000004,
+    WGPUBackendType_Metal = 0x00000005,
+    WGPUBackendType_Vulkan = 0x00000006,
+    WGPUBackendType_OpenGL = 0x00000007,
+    WGPUBackendType_OpenGLES = 0x00000008,
     WGPUBackendType_Force32 = 0x7FFFFFFF
 } WGPUBackendType WGPU_ENUM_ATTRIBUTE;
 
@@ -968,6 +969,7 @@ typedef struct WGPURequestAdapterOptions {
     WGPUChainedStruct const * nextInChain;
     WGPU_NULLABLE WGPUSurface compatibleSurface;
     WGPUPowerPreference powerPreference;
+    WGPUBackendType backendType;
     bool forceFallbackAdapter;
 } WGPURequestAdapterOptions WGPU_STRUCTURE_ATTRIBUTE;
 


### PR DESCRIPTION
Applications may want to request a particular backend when getting an adapter. This PR adds member `WGPUBackendType backendType` to WGPURequestAdapterOptions.

It also adds WGPUBackendType_Undefined which means the application does not care what backend type adapter it gets.