### PR TITLE
Change PreMul/UnPreMul capitalization to Premul/Unpremul

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -288,8 +288,8 @@ typedef enum WGPUCompilationMessageType {
 typedef enum WGPUCompositeAlphaMode {
     WGPUCompositeAlphaMode_Auto = 0x00000000,
     WGPUCompositeAlphaMode_Opaque = 0x00000001,
-    WGPUCompositeAlphaMode_PreMultiplied = 0x00000002,
-    WGPUCompositeAlphaMode_UnPreMultiplied = 0x00000003,
+    WGPUCompositeAlphaMode_Premultiplied = 0x00000002,
+    WGPUCompositeAlphaMode_Unpremultiplied = 0x00000003,
     WGPUCompositeAlphaMode_Inherit = 0x00000004,
     WGPUCompositeAlphaMode_Force32 = 0x7FFFFFFF
 } WGPUCompositeAlphaMode WGPU_ENUM_ATTRIBUTE;


### PR DESCRIPTION
"premultiplied" and "unpremultiplied" are used as single, unhyphenated words in the JS spec, so use the same capitalization here to match.

Follow-up to #203