### PR TITLE
Use WGPUTextureUsageFlags in WGPUSurfaceConfiguration

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1061,7 +1061,7 @@ typedef struct WGPUSurfaceConfiguration {
     WGPUChainedStruct const * nextInChain;
     WGPUDevice device;
     WGPUTextureFormat format;
-    WGPUTextureUsage usage;
+    WGPUTextureUsageFlags usage;
     size_t viewFormatCount;
     WGPUTextureFormat const * viewFormats;
     WGPUCompositeAlphaMode alphaMode;


### PR DESCRIPTION
The TextureUsage is a Bitmask, update the usage in SurfaceConfiguration to use the Flags typedef to be consistent with out uses of TextureUsage.

Follow-up to #203