### PR TITLE
Make WGPURenderPassColorAttachment extendable.

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1232,6 +1232,7 @@ typedef struct WGPUProgrammableStageDescriptor {
 } WGPUProgrammableStageDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassColorAttachment {
+    WGPUChainedStruct const * nextInChain;
     WGPU_NULLABLE WGPUTextureView view;
     WGPU_NULLABLE WGPUTextureView resolveTarget;
     WGPULoadOp loadOp;


### PR DESCRIPTION
Update WGPURenderPassColorAttachment as extendable to match the current usage in Dawn which extends the structure.