### PR TITLE
Add new WGPULimit value

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -870,6 +870,7 @@ typedef struct WGPULimits {
     uint32_t maxTextureDimension3D;
     uint32_t maxTextureArrayLayers;
     uint32_t maxBindGroups;
+    uint32_t maxBindGroupsPlusVertexBuffers;
     uint32_t maxBindingsPerBindGroup;
     uint32_t maxDynamicUniformBuffersPerPipelineLayout;
     uint32_t maxDynamicStorageBuffersPerPipelineLayout;


### PR DESCRIPTION
Add the maxBindGroupsPlusVertexBuffers entry to WGPULimits.