### PR TITLE
s/PipelineStatisticsQuery/ChromiumExperimentalPipelineStatisticsQuery/g

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -340,7 +340,7 @@ typedef enum WGPUFeatureName {
     WGPUFeatureName_DepthClipControl = 0x00000001,
     WGPUFeatureName_Depth32FloatStencil8 = 0x00000002,
     WGPUFeatureName_TimestampQuery = 0x00000003,
-    WGPUFeatureName_PipelineStatisticsQuery = 0x00000004,
+    WGPUFeatureName_ChromiumExperimentalPipelineStatisticsQuery = 0x00000004,
     WGPUFeatureName_TextureCompressionBC = 0x00000005,
     WGPUFeatureName_TextureCompressionETC2 = 0x00000006,
     WGPUFeatureName_TextureCompressionASTC = 0x00000007,


### PR DESCRIPTION
Following https://dawn-review.googlesource.com/c/dawn/+/156823, this PR renames the feature name `WGPUFeatureName_PipelineStatisticsQuery` to `WGPUFeatureName_ChromiumExperimentalPipelineStatisticsQuery`

@kainino0x Please review. 