### PR TITLE
Xlib's Window changed to u64, conforming to X.h

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1096,7 +1096,7 @@ typedef struct WGPUSurfaceDescriptorFromXcbWindow {
 typedef struct WGPUSurfaceDescriptorFromXlibWindow {
     WGPUChainedStruct chain;
     void * display;
-    uint32_t window;
+    uint64_t window;
 } WGPUSurfaceDescriptorFromXlibWindow WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUSurfaceTexture {


### PR DESCRIPTION
As per https://github.com/gfx-rs/wgpu-native/issues/304. The type definition for the X Window handles can be found at https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/master/include/X11/X.h?ref_type=heads#L96. `Window` is of type `XID` = `u64`.