### PR TITLE
Add const qualifier to SurfaceCapabilities lists

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1030,11 +1030,11 @@ typedef struct WGPUStorageTextureBindingLayout {
 typedef struct WGPUSurfaceCapabilities {
     WGPUChainedStructOut * nextInChain;
     size_t formatCount;
-    WGPUTextureFormat * formats;
+    WGPUTextureFormat const * formats;
     size_t presentModeCount;
-    WGPUPresentMode * presentModes;
+    WGPUPresentMode const * presentModes;
     size_t alphaModeCount;
-    WGPUCompositeAlphaMode * alphaModes;
+    WGPUCompositeAlphaMode const * alphaModes;
 } WGPUSurfaceCapabilities WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUSurfaceConfiguration {


### PR DESCRIPTION
The end user of GetCapabilities should not be allowed to mutate capabilities as far as I understand it.