### PR TITLE
Rename gen-check job

### DIFF
--- a/.github/workflows/gen-check.yml
+++ b/.github/workflows/gen-check.yml
@@ -2,7 +2,7 @@ name: gen-check
 on:
   pull_request:
 jobs:
-  compile:
+  gen-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Turns out this job name is the one that shows up in the GitHub UI for checks on a PR after it lands. Update it so it's possible to tell which one it is (in cases where GitHub doesn't show the workflow name):

![image](https://github.com/webgpu-native/webgpu-headers/assets/606355/fb229245-dad0-49e8-97f8-8a502df7d6d7)
