### PR TITLE
gen: extended headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,8 @@ gen: schema.json webgpu.yml
 	go run ./gen -schema schema.json -yaml webgpu.yml -header webgpu.h
 
 gen-check: gen
-	@git diff --quiet -- webgpu.h || { git diff -- webgpu.h; exit 1; }
+	@git diff --quiet -- webgpu.h || {                                                      \
+		echo "error: The re-generated header from yml doesn't match the checked-in header"; \
+		git diff -- webgpu.h;                                                               \
+		exit 1;                                                                             \
+	}

--- a/gen/README.md
+++ b/gen/README.md
@@ -2,6 +2,18 @@
 
 The generator for generating `webgpu.h` header and other extension headers or implementation specific headers from the yaml spec files.
 
+# Generate implementation specific header
+
+The generator also allows generating custom implementation specific headers that build on top of `webgpu.h` header. The generator accepts the combination of `-yaml` & `-header` flags in sequence, which it uses to validate the specifications and then generate their headers.
+
+For example, if `wgpu.yml` contains the implementation specific API, the header can be generated using:
+
+```shell
+> go run ./gen -schema schema.json -yaml webgpu.yml -header webgpu.h -yaml wgpu.yml -header wgpu.h
+```
+
+Since the generator does some duplication validation, the order of the files matter, so generator mandates the core `webgpu.yml` to be first in the sequence.
+
 # yaml spec
 
 ### Types

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -84,7 +84,7 @@ struct WGPU{{.Name | PascalCase}};
 {{- range $enum := .Enums}}
 {{-   if .Extended}}
 {{-     range $entryIndex, $_ := .Entries}}
-__WGPU_EXTEND_ENUM(WGPU{{ $enum.Name | PascalCase }}, WGPU{{ $enum.Name | PascalCase}}_{{.Name | PascalCase}}, {{EnumValue $.EnumPrefix $enum $entryIndex}});
+__WGPU_EXTEND_ENUM(WGPU{{$enum.Name | PascalCase}}, WGPU{{$enum.Name | PascalCase}}_{{.Name | PascalCase}}, {{EnumValue $.EnumPrefix $enum $entryIndex}});
 {{-     end}}
 {{-   else}}
 {{-     MComment .Doc 0}}
@@ -99,15 +99,21 @@ typedef enum WGPU{{.Name | PascalCase}} {
 {{  end}}
 
 {{- range $bitflag := .Bitflags}}
-{{-   MComment .Doc 0}}
+{{-   if .Extended}}
+{{-     range $entryIndex, $_ := .Entries}}
+__WGPU_EXTEND_ENUM(WGPU{{$bitflag.Name | PascalCase}}, WGPU{{$bitflag.Name | PascalCase}}_{{.Name | PascalCase}}, {{BitflagValue $bitflag $entryIndex}});
+{{-     end}}
+{{-   else}}
+{{-     MComment .Doc 0}}
 typedef enum WGPU{{.Name | PascalCase}} {
-{{-   range $entryIndex, $_ := .Entries}}
-{{-     MComment .Doc 4}}
+{{-     range $entryIndex, $_ := .Entries}}
+{{-       MComment .Doc 4}}
     WGPU{{$bitflag.Name | PascalCase}}_{{.Name | PascalCase}} = {{BitflagValue $bitflag $entryIndex}},
-{{-   end}}
+{{-     end}}
     WGPU{{$bitflag.Name | PascalCase}}_Force32 = 0x7FFFFFFF
 } WGPU{{$bitflag.Name | PascalCase}} WGPU_ENUM_ATTRIBUTE;
 typedef WGPUFlags WGPU{{$bitflag.Name | PascalCase}}Flags WGPU_ENUM_ATTRIBUTE;
+{{-   end}}
 {{  end}}
 
 {{- if eq .Name "webgpu"}}

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -187,7 +187,7 @@ typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUDevice device, char const * procN
 {{-     MComment .Doc 0}}
 typedef {{FunctionReturns .}} (*WGPUProc{{$object.Name | PascalCase}}{{.Name | PascalCase}})({{FunctionArgs . $object}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-   end}}
-{{-   if not .IsStruct}}
+{{-   if not (or .IsStruct .Extended)}}
 typedef void (*WGPUProc{{.Name | PascalCase}}Reference)(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProc{{.Name | PascalCase}}Release)(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-   end}}
@@ -211,7 +211,7 @@ WGPU_EXPORT WGPUProc wgpuGetProcAddress(WGPUDevice device, char const * procName
 {{-     MComment .Doc 0}}
 WGPU_EXPORT {{FunctionReturns .}} wgpu{{$object.Name | PascalCase}}{{.Name | PascalCase}}({{FunctionArgs . $object}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-   end}}
-{{-   if not .IsStruct}}
+{{-   if not (or .IsStruct .Extended)}}
 WGPU_EXPORT void wgpu{{.Name | PascalCase}}Reference(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpu{{.Name | PascalCase}}Release(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-   end}}

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -57,7 +57,7 @@
 {{- if .Constants}}
 {{-   range .Constants}}
 {{-     MComment .Doc 0}}
-#define WGPU_{{.Name | ConstantCase}} ({{.Value | CValue}})
+#define WGPU_{{.Name | ConstantCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} ({{.Value | CValue}})
 {{-   end}}
 {{  end}}
 
@@ -69,7 +69,7 @@ typedef uint32_t WGPUBool;
 {{- if .Objects}}
 {{-   range .Objects}}
 {{-     if not .IsStruct}}
-typedef struct WGPU{{.Name | PascalCase}}Impl* WGPU{{.Name | PascalCase}} WGPU_OBJECT_ATTRIBUTE;
+typedef struct WGPU{{.Name | PascalCase}}{{$.ExtSuffix}}Impl* WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} WGPU_OBJECT_ATTRIBUTE;
 {{-     end}}
 {{-   end}}
 {{  end}}
@@ -77,42 +77,42 @@ typedef struct WGPU{{.Name | PascalCase}}Impl* WGPU{{.Name | PascalCase}} WGPU_O
 {{- if .Structs}}
 // Structure forward declarations
 {{-   range .Structs}}
-struct WGPU{{.Name | PascalCase}};
+struct WGPU{{.Name | PascalCase}}{{$.ExtSuffix}};
 {{-   end}}
 {{  end}}
 
 {{- range $enum := .Enums}}
 {{-   if .Extended}}
 {{-     range $entryIndex, $_ := .Entries}}
-__WGPU_EXTEND_ENUM(WGPU{{$enum.Name | PascalCase}}, WGPU{{$enum.Name | PascalCase}}_{{.Name | PascalCase}}, {{EnumValue $.EnumPrefix $enum $entryIndex}});
+__WGPU_EXTEND_ENUM(WGPU{{$enum.Name | PascalCase}}, WGPU{{$enum.Name | PascalCase}}_{{.Name | PascalCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}}, {{EnumValue $.EnumPrefix $enum $entryIndex}});
 {{-     end}}
 {{-   else}}
 {{-     MComment .Doc 0}}
-typedef enum WGPU{{.Name | PascalCase}} {
+typedef enum WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} {
 {{-     range $entryIndex, $_ := .Entries}}
 {{-       MComment .Doc 4}}
-    WGPU{{$enum.Name | PascalCase}}_{{.Name | PascalCase}} = {{EnumValue $.EnumPrefix $enum $entryIndex}},
+    WGPU{{$enum.Name | PascalCase}}_{{.Name | PascalCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} = {{EnumValue $.EnumPrefix $enum $entryIndex}},
 {{-     end}}
-    WGPU{{$enum.Name | PascalCase}}_Force32 = 0x7FFFFFFF
-} WGPU{{$enum.Name | PascalCase}} WGPU_ENUM_ATTRIBUTE;
+    WGPU{{$enum.Name | PascalCase}}_Force32{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} = 0x7FFFFFFF
+} WGPU{{$enum.Name | PascalCase}}{{$.ExtSuffix}} WGPU_ENUM_ATTRIBUTE;
 {{-   end}}
 {{  end}}
 
 {{- range $bitflag := .Bitflags}}
 {{-   if .Extended}}
 {{-     range $entryIndex, $_ := .Entries}}
-__WGPU_EXTEND_ENUM(WGPU{{$bitflag.Name | PascalCase}}, WGPU{{$bitflag.Name | PascalCase}}_{{.Name | PascalCase}}, {{BitflagValue $bitflag $entryIndex}});
+__WGPU_EXTEND_ENUM(WGPU{{$bitflag.Name | PascalCase}}, WGPU{{$bitflag.Name | PascalCase}}_{{.Name | PascalCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}}, {{BitflagValue $bitflag $entryIndex}});
 {{-     end}}
 {{-   else}}
 {{-     MComment .Doc 0}}
-typedef enum WGPU{{.Name | PascalCase}} {
+typedef enum WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} {
 {{-     range $entryIndex, $_ := .Entries}}
 {{-       MComment .Doc 4}}
-    WGPU{{$bitflag.Name | PascalCase}}_{{.Name | PascalCase}} = {{BitflagValue $bitflag $entryIndex}},
+    WGPU{{$bitflag.Name | PascalCase}}_{{.Name | PascalCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} = {{BitflagValue $bitflag $entryIndex}},
 {{-     end}}
-    WGPU{{$bitflag.Name | PascalCase}}_Force32 = 0x7FFFFFFF
-} WGPU{{$bitflag.Name | PascalCase}} WGPU_ENUM_ATTRIBUTE;
-typedef WGPUFlags WGPU{{$bitflag.Name | PascalCase}}Flags WGPU_ENUM_ATTRIBUTE;
+    WGPU{{$bitflag.Name | PascalCase}}_Force32{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} = 0x7FFFFFFF
+} WGPU{{$bitflag.Name | PascalCase}}{{$.ExtSuffix}} WGPU_ENUM_ATTRIBUTE;
+typedef WGPUFlags WGPU{{$bitflag.Name | PascalCase}}Flags{{$.ExtSuffix}} WGPU_ENUM_ATTRIBUTE;
 {{-   end}}
 {{  end}}
 
@@ -122,7 +122,7 @@ typedef void (*WGPUProc)(void) WGPU_FUNCTION_ATTRIBUTE;
 
 {{- range .FunctionTypes}}
 {{-   MComment .Doc 0}}
-typedef {{FunctionReturns .}} (*WGPU{{.Name | PascalCase}})({{FunctionArgs . nil}}) WGPU_FUNCTION_ATTRIBUTE;
+typedef {{FunctionReturns .}} (*WGPU{{.Name | PascalCase}}{{$.ExtSuffix}})({{FunctionArgs . nil}}) WGPU_FUNCTION_ATTRIBUTE;
 {{- end}}
 
 {{- if .Objects}}
@@ -130,7 +130,7 @@ typedef {{FunctionReturns .}} (*WGPU{{.Name | PascalCase}})({{FunctionArgs . nil
 {{-     range $method := .Methods}}
 {{-       if .ReturnsAsync}}
 {{-         MComment .Doc 0}}
-typedef void (*WGPU{{$object.Name | PascalCase}}{{$method.Name | PascalCase}}Callback)({{CallbackArgs .}}) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPU{{$object.Name | PascalCase}}{{$method.Name | PascalCase}}Callback{{$.ExtSuffix}})({{CallbackArgs .}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-       end}}
 {{-     end}}
 {{-   end}}
@@ -148,9 +148,9 @@ typedef struct WGPUChainedStructOut {
 } WGPUChainedStructOut WGPU_STRUCTURE_ATTRIBUTE;
 {{  end}}
 
-{{- range .Structs}}
+{{- range $struct := .Structs}}
 {{-   MComment .Doc 0}}
-typedef struct WGPU{{.Name | PascalCase}} {
+typedef struct WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} {
 {{-   if eq .Type "base_in" }}
     WGPUChainedStruct const * nextInChain;
 {{-   else if eq .Type "base_out" }}
@@ -160,17 +160,10 @@ typedef struct WGPU{{.Name | PascalCase}} {
 {{-   else if eq .Type "extension_out"}}
     WGPUChainedStructOut chain;
 {{-   end}}
-{{-   range .Members}}
-{{-     if IsArray .Type}}
-    size_t {{.Name | CamelCase | Singularize}}Count;
-{{-       MComment .Doc 4}}
-    {{ArrayType .Type .Pointer}} {{.Name | CamelCase}};
-{{-     else}}
-{{-       MComment .Doc 4}}
-    {{if .Optional}}WGPU_NULLABLE {{end}}{{CType .Type .Pointer}} {{.Name | CamelCase}};
-{{-     end}}
+{{-   range $memberIndex, $_ := .Members}}
+    {{  StructMember $struct $memberIndex}}
 {{-   end}}
-} WGPU{{.Name | PascalCase}} WGPU_STRUCTURE_ATTRIBUTE;
+} WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} WGPU_STRUCTURE_ATTRIBUTE;
 {{  end}}{{"\n" -}}
 
 #ifdef __cplusplus
@@ -181,7 +174,7 @@ extern "C" {
 
 {{- range .Functions}}
 {{-   MComment .Doc 0}}
-typedef {{FunctionReturns .}} (*WGPUProc{{.Name | PascalCase}})({{FunctionArgs . nil}}) WGPU_FUNCTION_ATTRIBUTE;
+typedef {{FunctionReturns .}} (*WGPUProc{{.Name | PascalCase}}{{$.ExtSuffix}})({{FunctionArgs . nil}}) WGPU_FUNCTION_ATTRIBUTE;
 {{- end}}
 {{- if eq .Name "webgpu"}}
 typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUDevice device, char const * procName) WGPU_FUNCTION_ATTRIBUTE;
@@ -191,11 +184,11 @@ typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUDevice device, char const * procN
 // Procs of {{$object.Name | PascalCase}}
 {{-   range $object.Methods}}
 {{-     MComment .Doc 0}}
-typedef {{FunctionReturns .}} (*WGPUProc{{$object.Name | PascalCase}}{{.Name | PascalCase}})({{FunctionArgs . $object}}) WGPU_FUNCTION_ATTRIBUTE;
+typedef {{FunctionReturns .}} (*WGPUProc{{$object.Name | PascalCase}}{{.Name | PascalCase}}{{$.ExtSuffix}})({{FunctionArgs . $object}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-   end}}
 {{-   if not (or .IsStruct .Extended)}}
-typedef void (*WGPUProc{{.Name | PascalCase}}Reference)(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUProc{{.Name | PascalCase}}Release)(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProc{{.Name | PascalCase}}Reference{{$.ExtSuffix}})(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProc{{.Name | PascalCase}}Release{{$.ExtSuffix}})(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-   end}}
 {{  end}}{{"\n" -}}
 
@@ -205,7 +198,7 @@ typedef void (*WGPUProc{{.Name | PascalCase}}Release)(WGPU{{.Name | PascalCase}}
 
 {{- range .Functions}}
 {{-   MComment .Doc 0}}
-WGPU_EXPORT {{FunctionReturns .}} wgpu{{.Name | PascalCase}}({{FunctionArgs . nil}}) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT {{FunctionReturns .}} wgpu{{.Name | PascalCase}}{{$.ExtSuffix}}({{FunctionArgs . nil}}) WGPU_FUNCTION_ATTRIBUTE;
 {{- end}}
 {{- if eq .Name "webgpu"}}
 WGPU_EXPORT WGPUProc wgpuGetProcAddress(WGPUDevice device, char const * procName) WGPU_FUNCTION_ATTRIBUTE;
@@ -215,11 +208,11 @@ WGPU_EXPORT WGPUProc wgpuGetProcAddress(WGPUDevice device, char const * procName
 // Methods of {{$object.Name | PascalCase}}
 {{-   range $object.Methods}}
 {{-     MComment .Doc 0}}
-WGPU_EXPORT {{FunctionReturns .}} wgpu{{$object.Name | PascalCase}}{{.Name | PascalCase}}({{FunctionArgs . $object}}) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT {{FunctionReturns .}} wgpu{{$object.Name | PascalCase}}{{.Name | PascalCase}}{{$.ExtSuffix}}({{FunctionArgs . $object}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-   end}}
 {{-   if not (or .IsStruct .Extended)}}
-WGPU_EXPORT void wgpu{{.Name | PascalCase}}Reference(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpu{{.Name | PascalCase}}Release(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpu{{.Name | PascalCase}}Reference{{$.ExtSuffix}}(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpu{{.Name | PascalCase}}Release{{$.ExtSuffix}}(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-   end}}
 {{  end}}{{"\n" -}}
 

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -37,7 +37,17 @@
 #define WGPU_NULLABLE
 #endif{{"\n" -}}
 
-{{if eq .Name "webgpu"}}
+{{- if ne .Name "webgpu"}}
+#if !defined(__WGPU_EXTEND_ENUM)
+#ifdef __cplusplus
+#define __WGPU_EXTEND_ENUM(E, N, V) static const E N = E(V)
+#else
+#define __WGPU_EXTEND_ENUM(E, N, V) static const E N = (E)(V)
+#endif
+#endif // !defined(__WGPU_EXTEND_ENUM)
+{{ end}}
+
+{{- if eq .Name "webgpu"}}
 #include <stdint.h>
 #include <stddef.h>
 {{else}}
@@ -46,7 +56,7 @@
 
 {{- if .Constants}}
 {{-   range .Constants}}
-{{- MComment .Doc 0}}
+{{-     MComment .Doc 0}}
 #define WGPU_{{.Name | ConstantCase}} ({{.Value | CValue}})
 {{-   end}}
 {{  end}}
@@ -71,49 +81,33 @@ struct WGPU{{.Name | PascalCase}};
 {{-   end}}
 {{  end}}
 
-{{- range $entry := .Enums}}
-{{-   MComment .Doc 0}}
-typedef enum WGPU{{.Name | PascalCase}} {
-{{-   range $entryIndex, $_ := .Entries}}
-{{-     MComment .Doc 4}}
-{{-     $entryValue := 0}}
-{{-     if eq .Value ""}}
-{{-       $entryValue = $entryIndex}}
-{{-     else}}
-{{-       $entryValue = ParseUint .Value 16}}
+{{- range $enum := .Enums}}
+{{-   if .Extended}}
+{{-     range $entryIndex, $_ := .Entries}}
+__WGPU_EXTEND_ENUM(WGPU{{ $enum.Name | PascalCase }}, WGPU{{ $enum.Name | PascalCase}}_{{.Name | PascalCase}}, {{EnumValue $.EnumPrefix $enum $entryIndex}});
 {{-     end}}
-    WGPU{{$entry.Name | PascalCase}}_{{.Name | PascalCase}} = {{printf "%s%.4X," $.EnumPrefix $entryValue}}
+{{-   else}}
+{{-     MComment .Doc 0}}
+typedef enum WGPU{{.Name | PascalCase}} {
+{{-     range $entryIndex, $_ := .Entries}}
+{{-       MComment .Doc 4}}
+    WGPU{{$enum.Name | PascalCase}}_{{.Name | PascalCase}} = {{EnumValue $.EnumPrefix $enum $entryIndex}},
+{{-     end}}
+    WGPU{{$enum.Name | PascalCase}}_Force32 = 0x7FFFFFFF
+} WGPU{{$enum.Name | PascalCase}} WGPU_ENUM_ATTRIBUTE;
 {{-   end}}
-    WGPU{{.Name | PascalCase}}_Force32 = 0x7FFFFFFF
-} WGPU{{.Name | PascalCase}} WGPU_ENUM_ATTRIBUTE;
 {{  end}}
 
-{{- range $entry := .Bitflags}}
+{{- range $bitflag := .Bitflags}}
 {{-   MComment .Doc 0}}
 typedef enum WGPU{{.Name | PascalCase}} {
 {{-   range $entryIndex, $_ := .Entries}}
 {{-     MComment .Doc 4}}
-{{-     $entryValue := ""}}
-{{-     $valueCombination := .ValueCombination}}
-{{-     range $valueIndex, $v := .ValueCombination}}
-{{-       $v = printf "WGPU%s_%s" ($entry.Name | PascalCase) ($v | PascalCase)}}
-{{-       if IsLast $valueIndex $valueCombination}}
-{{-         $entryValue = print $entryValue $v}}
-{{-       else}}
-{{-         $entryValue = print $entryValue $v " | "}}
-{{-       end}}
-{{-     else}}
-{{-       if eq .Value ""}}
-{{-         $entryValue = printf "0x%.8X" (BitFlagValue $entryIndex)}}
-{{-       else}}
-{{-         $entryValue = printf "0x%.8X" (ParseUint .Value 64)}}
-{{-       end}}
-{{-     end}}
-    WGPU{{$entry.Name | PascalCase}}_{{.Name | PascalCase}} = {{$entryValue}},
+    WGPU{{$bitflag.Name | PascalCase}}_{{.Name | PascalCase}} = {{BitflagValue $bitflag $entryIndex}},
 {{-   end}}
-    WGPU{{.Name | PascalCase}}_Force32 = 0x7FFFFFFF
-} WGPU{{.Name | PascalCase}} WGPU_ENUM_ATTRIBUTE;
-typedef WGPUFlags WGPU{{.Name | PascalCase}}Flags WGPU_ENUM_ATTRIBUTE;
+    WGPU{{$bitflag.Name | PascalCase}}_Force32 = 0x7FFFFFFF
+} WGPU{{$bitflag.Name | PascalCase}} WGPU_ENUM_ATTRIBUTE;
+typedef WGPUFlags WGPU{{$bitflag.Name | PascalCase}}Flags WGPU_ENUM_ATTRIBUTE;
 {{  end}}
 
 {{- if eq .Name "webgpu"}}

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -1,7 +1,7 @@
 {{- MCommentN .Copyright 0}}
 
-#ifndef {{.Name | ConstantCase}}_H_
-#define {{.Name | ConstantCase}}_H_
+#ifndef {{.HeaderName | ConstantCase}}_H_
+#define {{.HeaderName | ConstantCase}}_H_
 
 #if defined(WGPU_SHARED_LIBRARY)
 #    if defined(_WIN32)
@@ -222,4 +222,4 @@ WGPU_EXPORT void wgpu{{.Name | PascalCase}}Release{{$.ExtSuffix}}(WGPU{{.Name | 
 } // extern "C"
 #endif
 
-#endif // {{.Name | ConstantCase}}_H_
+#endif // {{.HeaderName | ConstantCase}}_H_

--- a/gen/main.go
+++ b/gen/main.go
@@ -19,12 +19,14 @@ var (
 	schemaPath  string
 	headerPaths StringListFlag
 	yamlPaths   StringListFlag
+	extSuffix   bool
 )
 
 func main() {
 	flag.StringVar(&schemaPath, "schema", "", "path of the json schema")
 	flag.Var(&yamlPaths, "yaml", "path of the yaml spec")
 	flag.Var(&headerPaths, "header", "output path of the header")
+	flag.BoolVar(&extSuffix, "extsuffix", true, "append suffix to extension identifiers")
 	flag.Parse()
 	if schemaPath == "" || len(headerPaths) == 0 || len(yamlPaths) == 0 || len(headerPaths) != len(yamlPaths) {
 		flag.Usage()
@@ -67,10 +69,16 @@ func main() {
 			panic("got invalid file name: " + fileName)
 		}
 
-		var data Data
-		data.Yml = &yml
-		data.Name = fileNameSplit[0]
-		if err := GenCHeader(&data, dst); err != nil {
+		suffix := ""
+		if fileNameSplit[0] != "webgpu" && extSuffix {
+			suffix = strings.ToUpper(fileNameSplit[0])
+		}
+		d := &Data{
+			Yml:       &yml,
+			Name:      fileNameSplit[0],
+			ExtSuffix: suffix,
+		}
+		if err := d.GenCHeader(dst); err != nil {
 			panic(err)
 		}
 	}

--- a/gen/main.go
+++ b/gen/main.go
@@ -98,6 +98,12 @@ func SortAndTransform(yml *Yml) {
 
 	// Sort bitflags
 	slices.SortStableFunc(yml.Bitflags, func(a, b Bitflag) int {
+		// We want to generate extended bitflag declarations before the normal ones.
+		if a.Extended && !b.Extended {
+			return -1
+		} else if !a.Extended && b.Extended {
+			return 1
+		}
 		return strings.Compare(PascalCase(a.Name), PascalCase(b.Name))
 	})
 

--- a/gen/main.go
+++ b/gen/main.go
@@ -45,7 +45,19 @@ func main() {
 
 	// Generate the header files
 	for i, yamlPath := range yamlPaths {
+		headerPath := headerPaths[i]
+		headerFileName := filepath.Base(headerPath)
+		headerFileNameSplit := strings.Split(headerFileName, ".")
+		if len(headerFileNameSplit) != 2 {
+			panic("got invalid header file name: " + headerFileName)
+		}
+
 		src, err := os.ReadFile(yamlPath)
+		if err != nil {
+			panic(err)
+		}
+
+		dst, err := os.Create(headerPath)
 		if err != nil {
 			panic(err)
 		}
@@ -57,28 +69,16 @@ func main() {
 
 		SortAndTransform(&yml)
 
-		headerPath := headerPaths[i]
-		dst, err := os.Create(headerPath)
-		if err != nil {
-			panic(err)
-		}
-
-		fileName := filepath.Base(yamlPath)
-		fileNameSplit := strings.Split(fileName, ".")
-		if len(fileNameSplit) != 2 {
-			panic("got invalid file name: " + fileName)
-		}
-
 		suffix := ""
-		if fileNameSplit[0] != "webgpu" && extSuffix {
-			suffix = strings.ToUpper(fileNameSplit[0])
+		if yml.Name != "webgpu" && extSuffix {
+			suffix = strings.ToUpper(yml.Name)
 		}
-		d := &Data{
-			Yml:       &yml,
-			Name:      fileNameSplit[0],
-			ExtSuffix: suffix,
+		g := &Generator{
+			Yml:        &yml,
+			HeaderName: headerFileNameSplit[0],
+			ExtSuffix:  suffix,
 		}
-		if err := d.GenCHeader(dst); err != nil {
+		if err := g.Gen(dst); err != nil {
 			panic(err)
 		}
 	}

--- a/gen/main.go
+++ b/gen/main.go
@@ -31,14 +31,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Order matters for validation steps, so enforce it.
 	if len(yamlPaths) > 1 && filepath.Base(yamlPaths[0]) != "webgpu.yml" {
 		panic(`"webgpu.yml" must be the first sequence in the order`)
 	}
 
+	// Validate the yaml files (jsonschema, duplications)
 	if err := ValidateYamls(schemaPath, yamlPaths); err != nil {
 		panic(err)
 	}
 
+	// Generate the header files
 	for i, yamlPath := range yamlPaths {
 		src, err := os.ReadFile(yamlPath)
 		if err != nil {
@@ -84,6 +87,7 @@ func SortAndTransform(yml *Yml) {
 
 	// Sort enums
 	slices.SortStableFunc(yml.Enums, func(a, b Enum) int {
+		// We want to generate extended enum declarations before the normal ones.
 		if a.Extended && !b.Extended {
 			return -1
 		} else if !a.Extended && b.Extended {

--- a/gen/main.go
+++ b/gen/main.go
@@ -72,14 +72,22 @@ func main() {
 func SortAndTransform(yml *Yml) {
 	// Sort structs
 	SortStructs(yml.Structs)
+
 	// Sort constants
 	slices.SortStableFunc(yml.Constants, func(a, b Constant) int {
 		return strings.Compare(PascalCase(a.Name), PascalCase(b.Name))
 	})
+
 	// Sort enums
 	slices.SortStableFunc(yml.Enums, func(a, b Enum) int {
+		if a.Extended && !b.Extended {
+			return -1
+		} else if !a.Extended && b.Extended {
+			return 1
+		}
 		return strings.Compare(PascalCase(a.Name), PascalCase(b.Name))
 	})
+
 	// Sort bitflags
 	slices.SortStableFunc(yml.Bitflags, func(a, b Bitflag) int {
 		return strings.Compare(PascalCase(a.Name), PascalCase(b.Name))
@@ -99,6 +107,7 @@ func SortAndTransform(yml *Yml) {
 	slices.SortStableFunc(yml.Objects, func(a, b Object) int {
 		return strings.Compare(PascalCase(a.Name), PascalCase(b.Name))
 	})
+
 	// Sort methods
 	for _, obj := range yml.Objects {
 		slices.SortStableFunc(obj.Methods, func(a, b Function) int {

--- a/gen/main.go
+++ b/gen/main.go
@@ -31,6 +31,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if len(yamlPaths) > 1 && filepath.Base(yamlPaths[0]) != "webgpu.yml" {
+		panic(`"webgpu.yml" must be the first sequence in the order`)
+	}
+
 	if err := ValidateYamls(schemaPath, yamlPaths); err != nil {
 		panic(err)
 	}

--- a/gen/validator.go
+++ b/gen/validator.go
@@ -89,6 +89,9 @@ func mergeAndValidateDuplicates(yamlPaths []string) (errs error) {
 					if slices.ContainsFunc(prevBf.Entries, func(e BitflagEntry) bool { return e.Name == entry.Name }) {
 						errs = errors.Join(errs, fmt.Errorf("merge: bitflags.%s.%s in %s was already found previously while parsing, duplicates are not allowed", bf.Name, entry.Name, yamlPath))
 					}
+					if entry.Value == "" && len(entry.ValueCombination) == 0 {
+						errs = errors.Join(errs, fmt.Errorf("merge: bitflags.%s.%s in %s was extended but doesn't have a value or value_combination, extended bitflag entries must have an explicit value", bf.Name, entry.Name, yamlPath))
+					}
 					prevBf.Entries = append(prevBf.Entries, entry)
 				}
 				bitflags[bf.Name] = prevBf

--- a/gen/validator.go
+++ b/gen/validator.go
@@ -12,6 +12,7 @@ import (
 )
 
 func ValidateYamls(schemaPath string, yamlPaths []string) error {
+	// Validation through json schema
 	for _, yamlPath := range yamlPaths {
 		yamlFile, err := os.ReadFile(yamlPath)
 		if err != nil {
@@ -28,6 +29,7 @@ func ValidateYamls(schemaPath string, yamlPaths []string) error {
 		}
 	}
 
+	// Validation of possible duplication of entries across multiple yaml files
 	if err := mergeAndValidateDuplicates(yamlPaths); err != nil {
 		panic(err)
 	}

--- a/gen/validator.go
+++ b/gen/validator.go
@@ -1,29 +1,127 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/goccy/go-yaml"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	_ "github.com/santhosh-tekuri/jsonschema/v5/httploader"
 )
 
-func ValidateYaml(schemaPath string, yamlPath string) error {
-	yamlFile, err := os.ReadFile(yamlPath)
-	if err != nil {
-		return fmt.Errorf("ValidateYaml: %w", err)
-	}
-	var yml map[string]any
-	if err := yaml.Unmarshal(yamlFile, &yml); err != nil {
-		return fmt.Errorf("ValidateYaml: %w", err)
+func ValidateYamls(schemaPath string, yamlPaths []string) error {
+	for _, yamlPath := range yamlPaths {
+		yamlFile, err := os.ReadFile(yamlPath)
+		if err != nil {
+			return fmt.Errorf("ValidateYaml: %w", err)
+		}
+		var yml map[string]any
+		if err := yaml.Unmarshal(yamlFile, &yml); err != nil {
+			return fmt.Errorf("ValidateYaml: %w", err)
+		}
+
+		schema := jsonschema.MustCompile(schemaPath)
+		if err := schema.Validate(yml); err != nil {
+			return fmt.Errorf("ValidateYaml: %w", err)
+		}
 	}
 
-	schema := jsonschema.MustCompile(schemaPath)
-	if err := schema.Validate(yml); err != nil {
-		return fmt.Errorf("ValidateYaml: %w", err)
+	if err := mergeAndValidateDuplicates(yamlPaths); err != nil {
+		panic(err)
 	}
 
 	// TODO: add dependency check validations
 	return nil
+}
+
+func mergeAndValidateDuplicates(yamlPaths []string) (errs error) {
+	constants := make(map[string]Constant)
+	enums := make(map[string]Enum)
+	bitflags := make(map[string]Bitflag)
+	functionTypes := make(map[string]Function)
+	structs := make(map[string]Struct)
+	functions := make(map[string]Function)
+	objects := make(map[string]Object)
+
+	for _, yamlPath := range yamlPaths {
+		src, err := os.ReadFile(yamlPath)
+		if err != nil {
+			panic(err)
+		}
+
+		var data Yml
+		if err := yaml.Unmarshal(src, &data); err != nil {
+			panic(err)
+		}
+
+		for _, c := range data.Constants {
+			if _, ok := constants[c.Name]; ok {
+				errs = errors.Join(errs, fmt.Errorf("merge: constants.%s in %s was already found previously while parsing, duplicates are not allowed", c.Name, yamlPath))
+			}
+			constants[c.Name] = c
+		}
+		for _, e := range data.Enums {
+			if prevEnum, ok := enums[e.Name]; ok {
+				if !e.Extended {
+					errs = errors.Join(errs, fmt.Errorf("merge: enums.%s in %s is being extended but isn't marked as one", e.Name, yamlPath))
+				}
+				for _, entry := range e.Entries {
+					if slices.ContainsFunc(prevEnum.Entries, func(e EnumEntry) bool { return e.Name == entry.Name }) {
+						errs = errors.Join(errs, fmt.Errorf("merge: enums.%s.%s in %s was already found previously while parsing, duplicates are not allowed", e.Name, entry.Name, yamlPath))
+					}
+					prevEnum.Entries = append(prevEnum.Entries, entry)
+				}
+				enums[e.Name] = prevEnum
+			} else {
+				enums[e.Name] = e
+			}
+		}
+		for _, bf := range data.Bitflags {
+			if prevBf, ok := bitflags[bf.Name]; ok {
+				for _, entry := range bf.Entries {
+					if slices.ContainsFunc(prevBf.Entries, func(e BitflagEntry) bool { return e.Name == entry.Name }) {
+						errs = errors.Join(errs, fmt.Errorf("merge: bitflags.%s.%s in %s was already found previously while parsing, duplicates are not allowed", bf.Name, entry.Name, yamlPath))
+					}
+					prevBf.Entries = append(prevBf.Entries, entry)
+				}
+				bitflags[bf.Name] = prevBf
+			} else {
+				bitflags[bf.Name] = bf
+			}
+		}
+		for _, ft := range data.FunctionTypes {
+			if _, ok := functionTypes[ft.Name]; ok {
+				errs = errors.Join(errs, fmt.Errorf("merge: function_types.%s in %s was already found previously while parsing, duplicates are not allowed", ft.Name, yamlPath))
+			}
+			functionTypes[ft.Name] = ft
+		}
+		for _, s := range data.Structs {
+			if _, ok := structs[s.Name]; ok {
+				errs = errors.Join(errs, fmt.Errorf("merge: structs.%s in %s was already found previously while parsing, duplicates are not allowed", s.Name, yamlPath))
+			}
+			structs[s.Name] = s
+		}
+		for _, f := range data.Functions {
+			if _, ok := functions[f.Name]; ok {
+				errs = errors.Join(errs, fmt.Errorf("merge: functions.%s in %s was already found previously while parsing, duplicates are not allowed", f.Name, yamlPath))
+			}
+			functions[f.Name] = f
+		}
+		for _, o := range data.Objects {
+			if prevObj, ok := objects[o.Name]; ok {
+				for _, method := range o.Methods {
+					if slices.ContainsFunc(prevObj.Methods, func(f Function) bool { return f.Name == method.Name }) {
+						errs = errors.Join(errs, fmt.Errorf("merge: objects.%s.%s in %s was already found previously while parsing, duplicates are not allowed", o.Name, method.Name, yamlPath))
+					}
+					prevObj.Methods = append(prevObj.Methods, method)
+				}
+				objects[o.Name] = prevObj
+			} else {
+				objects[o.Name] = o
+			}
+		}
+	}
+	return
 }

--- a/gen/validator.go
+++ b/gen/validator.go
@@ -82,6 +82,9 @@ func mergeAndValidateDuplicates(yamlPaths []string) (errs error) {
 		}
 		for _, bf := range data.Bitflags {
 			if prevBf, ok := bitflags[bf.Name]; ok {
+				if !bf.Extended {
+					errs = errors.Join(errs, fmt.Errorf("merge: bitflags.%s in %s is being extended but isn't marked as one", bf.Name, yamlPath))
+				}
 				for _, entry := range bf.Entries {
 					if slices.ContainsFunc(prevBf.Entries, func(e BitflagEntry) bool { return e.Name == entry.Name }) {
 						errs = errors.Join(errs, fmt.Errorf("merge: bitflags.%s.%s in %s was already found previously while parsing, duplicates are not allowed", bf.Name, entry.Name, yamlPath))
@@ -113,6 +116,9 @@ func mergeAndValidateDuplicates(yamlPaths []string) (errs error) {
 		}
 		for _, o := range data.Objects {
 			if prevObj, ok := objects[o.Name]; ok {
+				if !o.Extended {
+					errs = errors.Join(errs, fmt.Errorf("merge: objects.%s in %s is being extended but isn't marked as one", o.Name, yamlPath))
+				}
 				for _, method := range o.Methods {
 					if slices.ContainsFunc(prevObj.Methods, func(f Function) bool { return f.Name == method.Name }) {
 						errs = errors.Join(errs, fmt.Errorf("merge: objects.%s.%s in %s was already found previously while parsing, duplicates are not allowed", o.Name, method.Name, yamlPath))

--- a/gen/yml.go
+++ b/gen/yml.go
@@ -51,41 +51,6 @@ type BitflagEntry struct {
 	ValueCombination []string `yaml:"value_combination"`
 }
 
-type Function struct {
-	Name         string           `yaml:"name"`
-	Doc          string           `yaml:"doc"`
-	ReturnsAsync []FunctionArg    `yaml:"returns_async"`
-	Returns      *FunctionReturns `yaml:"returns"`
-	Args         []FunctionArg    `yaml:"args"`
-}
-type FunctionReturns struct {
-	Doc     string      `yaml:"doc"`
-	Type    string      `yaml:"type"`
-	Pointer PointerType `yaml:"pointer"`
-}
-type FunctionArg struct {
-	Name     string      `yaml:"name"`
-	Doc      string      `yaml:"doc"`
-	Type     string      `yaml:"type"`
-	Pointer  PointerType `yaml:"pointer"`
-	Optional bool        `yaml:"optional"`
-}
-
-type Struct struct {
-	Name        string         `yaml:"name"`
-	Type        string         `yaml:"type"`
-	Doc         string         `yaml:"doc"`
-	FreeMembers bool           `yaml:"free_members"`
-	Members     []StructMember `yaml:"members"`
-}
-type StructMember struct {
-	Name     string      `yaml:"name"`
-	Type     string      `yaml:"type"`
-	Pointer  PointerType `yaml:"pointer"`
-	Optional bool        `yaml:"optional"`
-	Doc      string      `yaml:"doc"`
-}
-
 type PointerType string
 
 const (
@@ -93,11 +58,37 @@ const (
 	PointerTypeImmutable PointerType = "immutable"
 )
 
+type ParameterType struct {
+	Name      string      `yaml:"name"`
+	Doc       string      `yaml:"doc"`
+	Type      string      `yaml:"type"`
+	Pointer   PointerType `yaml:"pointer"`
+	Optional  bool        `yaml:"optional"`
+	Namespace string      `yaml:"namespace"`
+}
+
+type Function struct {
+	Name         string          `yaml:"name"`
+	Doc          string          `yaml:"doc"`
+	ReturnsAsync []ParameterType `yaml:"returns_async"`
+	Returns      *ParameterType  `yaml:"returns"`
+	Args         []ParameterType `yaml:"args"`
+}
+
+type Struct struct {
+	Name        string          `yaml:"name"`
+	Type        string          `yaml:"type"`
+	Doc         string          `yaml:"doc"`
+	FreeMembers bool            `yaml:"free_members"`
+	Members     []ParameterType `yaml:"members"`
+}
+
 type Object struct {
-	Name     string     `yaml:"name"`
-	Doc      string     `yaml:"doc"`
-	Methods  []Function `yaml:"methods"`
-	Extended bool       `yaml:"extended"`
+	Name      string     `yaml:"name"`
+	Doc       string     `yaml:"doc"`
+	Methods   []Function `yaml:"methods"`
+	Extended  bool       `yaml:"extended"`
+	Namespace string     `yaml:"namespace"`
 
 	IsStruct bool `yaml:"-"`
 }

--- a/gen/yml.go
+++ b/gen/yml.go
@@ -18,8 +18,6 @@ type Yml struct {
 	Structs       []Struct   `yaml:"structs"`
 	Functions     []Function `yaml:"functions"`
 	Objects       []Object   `yaml:"objects"`
-
-	Copyrights []string `yaml:"-"`
 }
 
 type Constant struct {
@@ -29,16 +27,15 @@ type Constant struct {
 }
 
 type Enum struct {
-	Name    string      `yaml:"name"`
-	Doc     string      `yaml:"doc"`
-	Entries []EnumEntry `yaml:"entries"`
+	Name     string      `yaml:"name"`
+	Doc      string      `yaml:"doc"`
+	Entries  []EnumEntry `yaml:"entries"`
+	Extended bool        `yaml:"extended"`
 }
 type EnumEntry struct {
 	Name  string `yaml:"name"`
 	Doc   string `yaml:"doc"`
 	Value string `yaml:"value"`
-
-	ValuePrefix string `yaml:"-"`
 }
 
 type Bitflag struct {

--- a/gen/yml.go
+++ b/gen/yml.go
@@ -39,9 +39,10 @@ type EnumEntry struct {
 }
 
 type Bitflag struct {
-	Name    string         `yaml:"name"`
-	Doc     string         `yaml:"doc"`
-	Entries []BitflagEntry `yaml:"entries"`
+	Name     string         `yaml:"name"`
+	Doc      string         `yaml:"doc"`
+	Entries  []BitflagEntry `yaml:"entries"`
+	Extended bool           `yaml:"extended"`
 }
 type BitflagEntry struct {
 	Name             string   `yaml:"name"`
@@ -93,9 +94,10 @@ const (
 )
 
 type Object struct {
-	Name    string     `yaml:"name"`
-	Doc     string     `yaml:"doc"`
-	Methods []Function `yaml:"methods"`
+	Name     string     `yaml:"name"`
+	Doc      string     `yaml:"doc"`
+	Methods  []Function `yaml:"methods"`
+	Extended bool       `yaml:"extended"`
 
 	IsStruct bool `yaml:"-"`
 }

--- a/gen/yml.go
+++ b/gen/yml.go
@@ -9,6 +9,7 @@ import (
 
 type Yml struct {
 	Copyright  string `yaml:"copyright"`
+	Name       string `yaml:"name"`
 	EnumPrefix string `yaml:"enum_prefix"`
 
 	Constants     []Constant `yaml:"constants"`

--- a/schema.json
+++ b/schema.json
@@ -90,6 +90,11 @@
                 "optional": {
                     "type": "boolean",
                     "description": "Optional property, to indicate if a parameter is optional"
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Optional property, specifying the external namespace where this type is defined",
+                    "pattern": "^[a-z]+$"
                 }
             },
             "required": [
@@ -359,6 +364,11 @@
                     "extended": {
                         "type": "boolean",
                         "description": "Optional property, an indicator that this object is an extension of an already present object"
+                    },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional property, specifying the external namespace where this object is defined",
+                        "pattern": "^[a-z]+$"
                     },
                     "methods": {
                         "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -196,6 +196,10 @@
                     "doc": {
                         "type": "string"
                     },
+                    "extended": {
+                        "type": "boolean",
+                        "description": "Optional property, an indicator that this enum is an extension of an already present enum"
+                    },
                     "entries": {
                         "type": "array",
                         "items": {

--- a/schema.json
+++ b/schema.json
@@ -242,6 +242,10 @@
                     "doc": {
                         "type": "string"
                     },
+                    "extended": {
+                        "type": "boolean",
+                        "description": "Optional property, an indicator that this bitflag is an extension of an already present bitflag"
+                    },
                     "entries": {
                         "type": "array",
                         "items": {
@@ -351,6 +355,10 @@
                     },
                     "doc": {
                         "type": "string"
+                    },
+                    "extended": {
+                        "type": "boolean",
+                        "description": "Optional property, an indicator that this object is an extension of an already present object"
                     },
                     "methods": {
                         "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -160,6 +160,10 @@
             "type": "string",
             "description": "The license string to include at the top of the generated header"
         },
+        "name": {
+            "$ref": "#/definitions/Name",
+            "description": "The name/namespace of the specification"
+        },
         "enum_prefix": {
             "type": "string",
             "pattern": "^0x[0-9]{4}$",
@@ -382,6 +386,7 @@
     },
     "required": [
         "copyright",
+        "name",
         "enum_prefix",
         "constants",
         "enums",

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -3,6 +3,7 @@ copyright: |
 
   SPDX-License-Identifier: BSD-3-Clause
 
+name: webgpu
 enum_prefix: '0x0000'
 
 constants:


### PR DESCRIPTION
This PR finalizes the generations of implementation specific headers from custom yaml specifications aside from `webgpu.yml`.

Apart from the general struct extensions, the PR now allows extending `enums`, `bitflags` and `objects` with extra entires and functions across multiple yaml specifications.

#### Enums

Because C/C++ can't allow extending enums, we need to use casts, the downside being we loose exhaustive switches in C++ over new entries.

```c
#if !defined(__WGPU_EXTEND_ENUM)
#ifdef __cplusplus
#define __WGPU_EXTEND_ENUM(E, N, V) static const E N = E(V)
#else
#define __WGPU_EXTEND_ENUM(E, N, V) static const E N = (E)(V)
#endif
#endif // !defined(__WGPU_EXTEND_ENUM)

__WGPU_EXTEND_ENUM(WGPUFeatureName, WGPUFeatureName_PushConstants, 0x30000000);
__WGPU_EXTEND_ENUM(WGPUFeatureName, WGPUFeatureName_MultiDrawIndirect, 0x30000001);

__WGPU_EXTEND_ENUM(WGPUSType, WGPUSType_ShaderModuleGLSLDescriptor, 0x30000000);
__WGPU_EXTEND_ENUM(WGPUSType, WGPUSType_InstanceExtras, 0x30000001);
```

#### Bitflags

Currently extended bitflag entries are similar to enums, but I think we should change generation of all bitflag entries to be `static const T N = V` instead of enum, because we need to make them 64bit anyway. [Vulkan does the same for 64bit bitflags](https://github.com/KhronosGroup/Vulkan-Headers/blob/5ac36269f50381bdd92a5e1973d8eb041771e59e/include/vulkan/vulkan_core.h#L6538)

```c
__WGPU_EXTEND_ENUM(WGPUShaderStage, WGPUShaderStage_Mesh, 0x00000008);
```

### webgpu_ext.h

Though not needed, but with this PR we can now create a separate common extension header `webgpu_ext.h` and `webgpu_core.h` for core API. So that we can move any native-specific extensions (SPIRV shader) that we currently have in `webgpu.h` to `webgpu_ext.h` and `webgpu_core.h` would try to contain only JS spec API.

### Suffixes

Generator currently doesn't implicitly add any suffixes (`_DAWN`, `_WGPU`) to non-extended identifiers in extension headers, those will need to be added in the corresponding yaml specification explicitly, which I think is what we want because it's flexible that way.