### PR TITLE
gen: Support typedefs

### DIFF
--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -65,6 +65,10 @@
 typedef uint32_t WGPUFlags;
 typedef uint32_t WGPUBool;
 {{  end}}
+{{- range .Typedefs}}
+{{-   MComment .Doc 0}}
+typedef {{CType .Type "" ""}} WGPU{{.Name | PascalCase}}{{$.ExtSuffix}};
+{{  end}}
 
 {{- if .Objects}}
 {{-   range .Objects}}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -136,6 +136,9 @@ func (g *Generator) CType(typ string, pointerType PointerType, suffix string) st
 	case strings.HasPrefix(typ, "enum."):
 		ctype := "WGPU" + PascalCase(strings.TrimPrefix(typ, "enum.")) + suffix
 		return appendModifiers(ctype, pointerType)
+	case strings.HasPrefix(typ, "typedef."):
+		ctype := "WGPU" + PascalCase(strings.TrimPrefix(typ, "typedef.")) + suffix
+		return appendModifiers(ctype, pointerType)
 	case strings.HasPrefix(typ, "bitflag."):
 		ctype := "WGPU" + PascalCase(strings.TrimPrefix(typ, "bitflag.")) + "Flags" + suffix
 		return appendModifiers(ctype, pointerType)

--- a/gen/yml.go
+++ b/gen/yml.go
@@ -13,6 +13,7 @@ type Yml struct {
 	EnumPrefix string `yaml:"enum_prefix"`
 
 	Constants     []Constant `yaml:"constants"`
+	Typedefs      []Typedef  `yaml:"typedefs"`
 	Enums         []Enum     `yaml:"enums"`
 	Bitflags      []Bitflag  `yaml:"bitflags"`
 	FunctionTypes []Function `yaml:"function_types"`
@@ -25,6 +26,12 @@ type Constant struct {
 	Name  string `yaml:"name"`
 	Value string `yaml:"value"`
 	Doc   string `yaml:"doc"`
+}
+
+type Typedef struct {
+	Name string `yaml:"name"`
+	Doc  string `yaml:"doc"`
+	Type string `yaml:"type"`
 }
 
 type Enum struct {

--- a/schema.json
+++ b/schema.json
@@ -28,37 +28,43 @@
             "minimum": 0,
             "maximum": 65535
         },
+        "PrimitiveType": {
+            "type": "string",
+            "enum": [
+                "c_void",
+                "bool",
+                "string",
+                "uint16",
+                "uint32",
+                "uint64",
+                "usize",
+                "int16",
+                "int32",
+                "float32",
+                "float64",
+                "array<bool>",
+                "array<string>",
+                "array<uint16>",
+                "array<uint32>",
+                "array<uint64>",
+                "array<usize>",
+                "array<int16>",
+                "array<int32>",
+                "array<float32>",
+                "array<float64>"
+            ]
+        },
+        "ComplexType": {
+            "type": "string",
+            "pattern": "^(array<)?(typedef\\.|enum\\.|bitflag\\.|struct\\.|function_type\\.|object\\.)([a-zA-Z0-9]([a-zA-Z0-9_]*[a-zA-Z0-9])?)(>)?$"
+        },
         "Type": {
             "oneOf": [
                 {
-                    "type": "string",
-                    "enum": [
-                        "c_void",
-                        "bool",
-                        "string",
-                        "uint16",
-                        "uint32",
-                        "uint64",
-                        "usize",
-                        "int16",
-                        "int32",
-                        "float32",
-                        "float64",
-                        "array<bool>",
-                        "array<string>",
-                        "array<uint16>",
-                        "array<uint32>",
-                        "array<uint64>",
-                        "array<usize>",
-                        "array<int16>",
-                        "array<int32>",
-                        "array<float32>",
-                        "array<float64>"
-                    ]
+                    "$ref": "#/definitions/PrimitiveType"
                 },
                 {
-                    "type": "string",
-                    "pattern": "^(array<)?(enum\\.|bitflag\\.|struct\\.|function_type\\.|object\\.)([a-zA-Z0-9]([a-zA-Z0-9_]*[a-zA-Z0-9])?)(>)?$"
+                    "$ref": "#/definitions/ComplexType"
                 }
             ]
         },
@@ -168,6 +174,29 @@
             "type": "string",
             "pattern": "^0x[0-9]{4}$",
             "description": "The dedicated enum prefix for the implementation specific header to avoid collisions"
+        },
+        "typedefs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "description": "An alias of a primitive type",
+                "properties": {
+                    "name": {
+                        "$ref": "#/definitions/Name"
+                    },
+                    "doc": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/definitions/PrimitiveType"
+                    }
+                },
+                "required": [
+                    "name",
+                    "doc",
+                    "type"
+                ]
+            }
         },
         "constants": {
             "type": "array",
@@ -389,6 +418,7 @@
         "name",
         "enum_prefix",
         "constants",
+        "typedefs",
         "enums",
         "bitflags",
         "function_types",

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -44,6 +44,8 @@ constants:
     doc: |
       TODO
 
+typedefs: []
+
 enums:
   - name: request_adapter_status
     doc: |


### PR DESCRIPTION
Add support of specifying new typedefs for the header.

The existing `WGPUFlags` & `WGPUBool` don't belong in `webgpu.yml` because they are one of the C-isms which `webgpu.yml` tries to avoid, and instead it provides `bool` & `bitflag` types.