### PR TITLE
Add uncapturedErrorCallbackInfo to requestDevice descriptor

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -721,6 +721,7 @@ typedef void (*WGPUProc)(void) WGPU_FUNCTION_ATTRIBUTE;
 
 typedef void (*WGPUDeviceLostCallback)(WGPUDeviceLostReason reason, char const * message, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUErrorCallback)(WGPUErrorType type, char const * message, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUUncapturedErrorCallbackInfo)(WGPUErrorCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 
 typedef void (*WGPUAdapterRequestDeviceCallback)(WGPURequestDeviceStatus status, WGPUDevice device, char const * message, WGPU_NULLABLE void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUBufferMapAsyncCallback)(WGPUBufferMapAsyncStatus status, WGPU_NULLABLE void * userdata) WGPU_FUNCTION_ATTRIBUTE;
@@ -1278,6 +1279,7 @@ typedef struct WGPUDeviceDescriptor {
     WGPUQueueDescriptor defaultQueue;
     WGPUDeviceLostCallback deviceLostCallback;
     void * deviceLostUserdata;
+    WGPUUncapturedErrorCallbackInfo uncapturedErrorCallbackInfo;
 } WGPUDeviceDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassDescriptor {
@@ -1431,7 +1433,6 @@ typedef WGPUBool (*WGPUProcDeviceHasFeature)(WGPUDevice device, WGPUFeatureName 
 typedef void (*WGPUProcDevicePopErrorScope)(WGPUDevice device, WGPUErrorCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcDevicePushErrorScope)(WGPUDevice device, WGPUErrorFilter filter) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcDeviceSetLabel)(WGPUDevice device, char const * label) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUProcDeviceSetUncapturedErrorCallback)(WGPUDevice device, WGPUErrorCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcDeviceReference)(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcDeviceRelease)(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 
@@ -1670,7 +1671,6 @@ WGPU_EXPORT WGPUBool wgpuDeviceHasFeature(WGPUDevice device, WGPUFeatureName fea
 WGPU_EXPORT void wgpuDevicePopErrorScope(WGPUDevice device, WGPUErrorCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuDevicePushErrorScope(WGPUDevice device, WGPUErrorFilter filter) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuDeviceSetLabel(WGPUDevice device, char const * label) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuDeviceSetUncapturedErrorCallback(WGPUDevice device, WGPUErrorCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuDeviceReference(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuDeviceRelease(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 

--- a/webgpu.h
+++ b/webgpu.h
@@ -130,6 +130,7 @@ struct WGPUSurfaceTexture;
 struct WGPUTextureBindingLayout;
 struct WGPUTextureDataLayout;
 struct WGPUTextureViewDescriptor;
+struct WGPUUncapturedErrorCallbackInfo;
 struct WGPUVertexAttribute;
 struct WGPUBindGroupDescriptor;
 struct WGPUBindGroupLayoutEntry;
@@ -721,7 +722,6 @@ typedef void (*WGPUProc)(void) WGPU_FUNCTION_ATTRIBUTE;
 
 typedef void (*WGPUDeviceLostCallback)(WGPUDeviceLostReason reason, char const * message, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUErrorCallback)(WGPUErrorType type, char const * message, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUUncapturedErrorCallbackInfo)(WGPUErrorCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 
 typedef void (*WGPUAdapterRequestDeviceCallback)(WGPURequestDeviceStatus status, WGPUDevice device, char const * message, WGPU_NULLABLE void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUBufferMapAsyncCallback)(WGPUBufferMapAsyncStatus status, WGPU_NULLABLE void * userdata) WGPU_FUNCTION_ATTRIBUTE;
@@ -1124,6 +1124,12 @@ typedef struct WGPUTextureViewDescriptor {
     uint32_t arrayLayerCount;
     WGPUTextureAspect aspect;
 } WGPUTextureViewDescriptor WGPU_STRUCTURE_ATTRIBUTE;
+
+typedef struct WGPUUncapturedErrorCallbackInfo {
+    WGPUChainedStruct const * nextInChain;
+    WGPUErrorCallback callback;
+    void * userdata;
+} WGPUUncapturedErrorCallbackInfo WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUVertexAttribute {
     WGPUVertexFormat format;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1422,6 +1422,21 @@ function_types:
         type: c_void
         pointer: mutable
 
+  - name: uncaptured_error_callback_info
+    doc: |
+      TODO
+    type: base_in
+    args:
+      - name: callback
+        doc: |
+          TODO
+        type: function_type.error_callback
+      - name: userdata
+        doc: |
+          TODO
+        type: c_void
+        pointer: mutable
+
 structs:
   - name: request_adapter_options
     doc: |
@@ -1557,6 +1572,10 @@ structs:
           TODO
         type: c_void
         pointer: mutable
+      - name: uncaptured_error_callback_info
+        doc: |
+          TODO
+        type: function_type.uncaptured_error_callback_info
 
   - name: bind_group_entry
     doc: |
@@ -3901,19 +3920,6 @@ objects:
           doc: |
             TODO
           type: object.queue
-      - name: set_uncaptured_error_callback
-        doc: |
-          TODO
-        args:
-          - name: callback
-            doc: |
-              TODO
-            type: function_type.error_callback
-          - name: userdata
-            doc: |
-              TODO
-            type: c_void
-            pointer: mutable
       - name: push_error_scope
         doc: |
           TODO

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1422,21 +1422,6 @@ function_types:
         type: c_void
         pointer: mutable
 
-  - name: uncaptured_error_callback_info
-    doc: |
-      TODO
-    type: base_in
-    args:
-      - name: callback
-        doc: |
-          TODO
-        type: function_type.error_callback
-      - name: userdata
-        doc: |
-          TODO
-        type: c_void
-        pointer: mutable
-
 structs:
   - name: request_adapter_options
     doc: |
@@ -3110,6 +3095,21 @@ structs:
         doc: |
           TODO
         type: enum.texture_aspect
+
+  - name: uncaptured_error_callback_info
+    doc: |
+      TODO
+    type: base_in
+    members:
+      - name: callback
+        doc: |
+          TODO
+        type: function_type.error_callback
+      - name: userdata
+        doc: |
+          TODO
+        type: c_void
+        pointer: mutable
 
 functions:
   - name: create_instance


### PR DESCRIPTION
This PR adds `uncapturedErrorCallbackInfo` to `requestDevice()` descriptor to match recent Dawn changes at https://dawn-review.googlesource.com/c/dawn/+/183162.

It also removes `wgpuDeviceSetUncapturedErrorCallback` that will be deprecated with this new attribute.

Let me know if that looks good to you.