### PR TITLE
Add usages to WGPUSurfaceCapabilities

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1028,6 +1028,7 @@ typedef struct WGPUStorageTextureBindingLayout {
 
 typedef struct WGPUSurfaceCapabilities {
     WGPUChainedStructOut * nextInChain;
+    WGPUTextureUsageFlags usages;
     size_t formatCount;
     WGPUTextureFormat const * formats;
     size_t presentModeCount;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1667,6 +1667,10 @@ structs:
     type: base_out
     free_members: true
     members:
+      - name: usages
+        doc: |
+          TODO
+        type: bitflag.texture_usage
       - name: formats
         doc: |
           TODO


### PR DESCRIPTION
Following up on https://github.com/webgpu-native/webgpu-headers/issues/24#issuecomment-2153459448, this PR adds `usages` to `WGPUSurfaceCapabilities` similar to https://dawn-review.googlesource.com/c/dawn/+/189323