### PR TITLE
Remove WGPUAdapterProperties/wgpuAdapterGetProperties

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -120,7 +120,6 @@ typedef struct WGPUTextureViewImpl* WGPUTextureView WGPU_OBJECT_ATTRIBUTE;
 /** @} */
 // Structure forward declarations
 struct WGPUAdapterInfo;
-struct WGPUAdapterProperties;
 struct WGPUBindGroupEntry;
 struct WGPUBlendComponent;
 struct WGPUBufferBindingLayout;
@@ -834,18 +833,6 @@ typedef struct WGPUAdapterInfo {
     uint32_t deviceID;
 } WGPUAdapterInfo WGPU_STRUCTURE_ATTRIBUTE;
 
-typedef struct WGPUAdapterProperties {
-    WGPUChainedStructOut * nextInChain;
-    uint32_t vendorID;
-    char const * vendorName;
-    char const * architecture;
-    uint32_t deviceID;
-    char const * name;
-    char const * driverDescription;
-    WGPUAdapterType adapterType;
-    WGPUBackendType backendType;
-} WGPUAdapterProperties WGPU_STRUCTURE_ATTRIBUTE;
-
 typedef struct WGPUBindGroupEntry {
     WGPUChainedStruct const * nextInChain;
     uint32_t binding;
@@ -1426,7 +1413,6 @@ typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUDevice device, char const * procN
 typedef size_t (*WGPUProcAdapterEnumerateFeatures)(WGPUAdapter adapter, WGPUFeatureName * features) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcAdapterGetInfo)(WGPUAdapter adapter, WGPUAdapterInfo * info) WGPU_FUNCTION_ATTRIBUTE;
 typedef WGPUBool (*WGPUProcAdapterGetLimits)(WGPUAdapter adapter, WGPUSupportedLimits * limits) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUProcAdapterGetProperties)(WGPUAdapter adapter, WGPUAdapterProperties * properties) WGPU_FUNCTION_ATTRIBUTE;
 typedef WGPUBool (*WGPUProcAdapterHasFeature)(WGPUAdapter adapter, WGPUFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcAdapterRequestDevice)(WGPUAdapter adapter, WGPU_NULLABLE WGPUDeviceDescriptor const * descriptor, WGPUAdapterRequestDeviceCallback callback, WGPU_NULLABLE void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcAdapterReference)(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;
@@ -1683,7 +1669,6 @@ WGPU_EXPORT WGPUProc wgpuGetProcAddress(WGPUDevice device, char const * procName
 WGPU_EXPORT size_t wgpuAdapterEnumerateFeatures(WGPUAdapter adapter, WGPUFeatureName * features) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuAdapterGetInfo(WGPUAdapter adapter, WGPUAdapterInfo * info) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBool wgpuAdapterGetLimits(WGPUAdapter adapter, WGPUSupportedLimits * limits) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuAdapterGetProperties(WGPUAdapter adapter, WGPUAdapterProperties * properties) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBool wgpuAdapterHasFeature(WGPUAdapter adapter, WGPUFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuAdapterRequestDevice(WGPUAdapter adapter, WGPU_NULLABLE WGPUDeviceDescriptor const * descriptor, WGPUAdapterRequestDeviceCallback callback, WGPU_NULLABLE void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuAdapterReference(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1485,44 +1485,6 @@ structs:
           TODO
         type: uint32
 
-  - name: adapter_properties
-    doc: |
-      TODO
-    type: base_out
-    members:
-      - name: vendor_ID
-        doc: |
-          TODO
-        type: uint32
-      - name: vendor_name
-        doc: |
-          TODO
-        type: string
-      - name: architecture
-        doc: |
-          TODO
-        type: string
-      - name: device_ID
-        doc: |
-          TODO
-        type: uint32
-      - name: name
-        doc: |
-          TODO
-        type: string
-      - name: driver_description
-        doc: |
-          TODO
-        type: string
-      - name: adapter_type
-        doc: |
-          TODO
-        type: enum.adapter_type
-      - name: backend_type
-        doc: |
-          TODO
-        type: enum.backend_type
-
   - name: device_descriptor
     doc: |
       TODO
@@ -3148,15 +3110,6 @@ objects:
             doc: |
               TODO
             type: struct.supported_limits
-            pointer: mutable
-      - name: get_properties
-        doc: |
-          TODO
-        args:
-          - name: properties
-            doc: |
-              TODO
-            type: struct.adapter_properties
             pointer: mutable
       - name: has_feature
         doc: |


### PR DESCRIPTION
As raised in https://github.com/webgpu-native/webgpu-headers/issues/266#issuecomment-2161376895, this PR removes WGPUAdapterProperties/wgpuAdapterGetProperties. The new wgpuAdapterGetInfo replaces both wgpuAdapterRequestAdapterInfo and wgpuAdapterGetProperties (that's why we added the vendor/device ID to the struct).

FIX https://github.com/webgpu-native/webgpu-headers/issues/266

