### PR TITLE
Drop Descriptor from SType enums

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -462,16 +462,16 @@ typedef enum WGPURequestDeviceStatus {
 
 typedef enum WGPUSType {
     WGPUSType_Invalid = 0x00000000,
-    WGPUSType_SurfaceDescriptorFromMetalLayer = 0x00000001,
-    WGPUSType_SurfaceDescriptorFromWindowsHWND = 0x00000002,
-    WGPUSType_SurfaceDescriptorFromXlibWindow = 0x00000003,
-    WGPUSType_SurfaceDescriptorFromCanvasHTMLSelector = 0x00000004,
-    WGPUSType_ShaderModuleSPIRVDescriptor = 0x00000005,
-    WGPUSType_ShaderModuleWGSLDescriptor = 0x00000006,
+    WGPUSType_SurfaceFromMetalLayer = 0x00000001,
+    WGPUSType_SurfaceFromWindowsHWND = 0x00000002,
+    WGPUSType_SurfaceFromXlibWindow = 0x00000003,
+    WGPUSType_SurfaceFromCanvasHTMLSelector = 0x00000004,
+    WGPUSType_ShaderModuleSPIRV = 0x00000005,
+    WGPUSType_ShaderModuleWGSL = 0x00000006,
     WGPUSType_PrimitiveDepthClipControl = 0x00000007,
-    WGPUSType_SurfaceDescriptorFromWaylandSurface = 0x00000008,
-    WGPUSType_SurfaceDescriptorFromAndroidNativeWindow = 0x00000009,
-    WGPUSType_SurfaceDescriptorFromXcbWindow = 0x0000000A,
+    WGPUSType_SurfaceFromWaylandSurface = 0x00000008,
+    WGPUSType_SurfaceFromAndroidNativeWindow = 0x00000009,
+    WGPUSType_SurfaceFromXcbWindow = 0x0000000A,
     WGPUSType_RenderPassDescriptorMaxDrawCount = 0x0000000F,
     WGPUSType_Force32 = 0x7FFFFFFF
 } WGPUSType WGPU_ENUM_ATTRIBUTE;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -592,34 +592,34 @@ enums:
       - name: invalid
         doc: |
           TODO
-      - name: surface_descriptor_from_metal_layer
+      - name: surface_from_metal_layer
         doc: |
           TODO
-      - name: surface_descriptor_from_windows_HWND
+      - name: surface_from_windows_HWND
         doc: |
           TODO
-      - name: surface_descriptor_from_xlib_window
+      - name: surface_from_xlib_window
         doc: |
           TODO
-      - name: surface_descriptor_from_canvas_HTML_selector
+      - name: surface_from_canvas_HTML_selector
         doc: |
           TODO
-      - name: shader_module_SPIRV_descriptor
+      - name: shader_module_SPIRV
         doc: |
           TODO
-      - name: shader_module_WGSL_descriptor
+      - name: shader_module_WGSL
         doc: |
           TODO
       - name: primitive_depth_clip_control
         doc: |
           TODO
-      - name: surface_descriptor_from_wayland_surface
+      - name: surface_from_wayland_surface
         doc: |
           TODO
-      - name: surface_descriptor_from_android_native_window
+      - name: surface_from_android_native_window
         doc: |
           TODO
-      - name: surface_descriptor_from_xcb_window
+      - name: surface_from_xcb_window
         doc: |
           TODO
       - name: render_pass_descriptor_max_draw_count


### PR DESCRIPTION
I missed updating SType enums in https://github.com/webgpu-native/webgpu-headers/pull/309. Sorry for that.
