### PR TITLE
Remove emscripten-only extension; slightly reorder SType

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: gen gen-check doc
+.PHONY: help gen gen-check doc
+
+# default target if you just type `make`
+help:
+	@echo 'Targets are: help, fix, gen, gen-check, doc'
 
 fix: webgpu.yml
 	go run ./fix -yaml webgpu.yml

--- a/webgpu.h
+++ b/webgpu.h
@@ -157,7 +157,6 @@ struct WGPUSurfaceCapabilities;
 struct WGPUSurfaceConfiguration;
 struct WGPUSurfaceDescriptor;
 struct WGPUSurfaceSourceAndroidNativeWindow;
-struct WGPUSurfaceSourceCanvasHTMLSelector_Emscripten;
 struct WGPUSurfaceSourceMetalLayer;
 struct WGPUSurfaceSourceWaylandSurface;
 struct WGPUSurfaceSourceWindowsHWND;
@@ -537,16 +536,15 @@ typedef enum WGPURequestDeviceStatus {
 
 typedef enum WGPUSType {
     WGPUSType_Invalid = 0x00000000,
-    WGPUSType_SurfaceSourceMetalLayer = 0x00000001,
-    WGPUSType_SurfaceSourceWindowsHWND = 0x00000002,
-    WGPUSType_SurfaceSourceXlibWindow = 0x00000003,
-    WGPUSType_SurfaceSourceCanvasHTMLSelector_Emscripten = 0x00000004,
-    WGPUSType_ShaderSourceSPIRV = 0x00000005,
-    WGPUSType_ShaderSourceWGSL = 0x00000006,
+    WGPUSType_ShaderSourceSPIRV = 0x00000001,
+    WGPUSType_ShaderSourceWGSL = 0x00000002,
+    WGPUSType_RenderPassMaxDrawCount = 0x00000003,
+    WGPUSType_SurfaceSourceMetalLayer = 0x00000004,
+    WGPUSType_SurfaceSourceWindowsHWND = 0x00000005,
+    WGPUSType_SurfaceSourceXlibWindow = 0x00000006,
     WGPUSType_SurfaceSourceWaylandSurface = 0x00000007,
     WGPUSType_SurfaceSourceAndroidNativeWindow = 0x00000008,
     WGPUSType_SurfaceSourceXCBWindow = 0x00000009,
-    WGPUSType_RenderPassMaxDrawCount = 0x0000000F,
     WGPUSType_Force32 = 0x7FFFFFFF
 } WGPUSType WGPU_ENUM_ATTRIBUTE;
 
@@ -1328,11 +1326,6 @@ typedef struct WGPUSurfaceSourceAndroidNativeWindow {
     WGPUChainedStruct chain;
     void * window;
 } WGPUSurfaceSourceAndroidNativeWindow WGPU_STRUCTURE_ATTRIBUTE;
-
-typedef struct WGPUSurfaceSourceCanvasHTMLSelector_Emscripten {
-    WGPUChainedStruct chain;
-    char const * selector;
-} WGPUSurfaceSourceCanvasHTMLSelector_Emscripten WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUSurfaceSourceMetalLayer {
     WGPUChainedStruct chain;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -718,6 +718,16 @@ enums:
       - name: invalid
         doc: |
           TODO
+      - name: shader_source_SPIRV
+        doc: |
+          TODO
+      - name: shader_source_WGSL
+        doc: |
+          TODO
+      - name: render_pass_max_draw_count
+        doc: |
+          TODO
+      # TODO(#214): Move all of the surface sources into block 0x0001
       - name: surface_source_metal_layer
         doc: |
           TODO
@@ -727,15 +737,6 @@ enums:
       - name: surface_source_xlib_window
         doc: |
           TODO
-      - name: surface_source_canvas_HTML_selector__Emscripten
-        doc: |
-          TODO
-      - name: shader_source_SPIRV
-        doc: |
-          TODO
-      - name: shader_source_WGSL
-        doc: |
-          TODO
       - name: surface_source_wayland_surface
         doc: |
           TODO
@@ -743,10 +744,6 @@ enums:
         doc: |
           TODO
       - name: surface_source_XCB_window
-        doc: |
-          TODO
-      - name: render_pass_max_draw_count
-        value: 0x000F
         doc: |
           TODO
   - name: sampler_binding_type
@@ -2780,17 +2777,6 @@ structs:
           TODO
         type: c_void
         pointer: mutable
-  - name: surface_source_canvas_HTML_selector__Emscripten
-    doc: |
-      TODO
-    type: extension_in
-    extends:
-      - surface_descriptor
-    members:
-      - name: selector
-        doc: |
-          TODO
-        type: string
   - name: surface_source_metal_layer
     doc: |
       TODO


### PR DESCRIPTION
Emscripten will keep this (under the new name) but it's not "standardized" in this header yet.

> All of the SurfaceSource extensions are going to get moved into the `0x0001_????` block (they're already moved in Dawn but we haven't moved them in here yet).
> 
> So reordering these puts the other 3 STypes in the exact positions I think they'll be when the header becomes stable.

Issue: https://github.com/webgpu-native/webgpu-headers/issues/214#issuecomment-2237722493