### PR TITLE
Add rgb10a2 vertex format

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -762,6 +762,7 @@ typedef enum WGPUVertexFormat {
     WGPUVertexFormat_Sint32x2 = 0x0000001C,
     WGPUVertexFormat_Sint32x3 = 0x0000001D,
     WGPUVertexFormat_Sint32x4 = 0x0000001E,
+    WGPUVertexFormat_Unorm10_10_10_2 = 0x0000001F,
     WGPUVertexFormat_Force32 = 0x7FFFFFFF
 } WGPUVertexFormat WGPU_ENUM_ATTRIBUTE;
 


### PR DESCRIPTION
According to: https://github.com/gpuweb/gpuweb/issues/4275

Value from dawn: https://github.com/google/dawn/blob/efbc7fb59702b1abfdd9b95e1b03cb84678747ca/src/dawn/dawn.json#L4699

For some reason all this values differs in wgpu: 
https://github.com/gfx-rs/wgpu/blob/a93dcb646a6ea040e97950d74e10c757051b35bb/wgpu-types/src/lib.rs#L5202C5-L5202C20