### PR TITLE
Use same order between LoadOp and StoreOp

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -471,8 +471,8 @@ typedef enum WGPUIndexFormat {
 
 typedef enum WGPULoadOp {
     WGPULoadOp_Undefined = 0x00000000,
-    WGPULoadOp_Clear = 0x00000001,
-    WGPULoadOp_Load = 0x00000002,
+    WGPULoadOp_Load = 0x00000001,
+    WGPULoadOp_Clear = 0x00000002,
     WGPULoadOp_Force32 = 0x7FFFFFFF
 } WGPULoadOp WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -514,10 +514,10 @@ enums:
       - name: undefined
         doc: |
           TODO
-      - name: clear
+      - name: load
         doc: |
           TODO
-      - name: load
+      - name: clear
         doc: |
           TODO
   - name: map_async_status


### PR DESCRIPTION
Just a minor consistency thing:
load,clear
store,discard

This order is the same order it's written in the upstream JS spec (though JS doesn't actually care about the order) as well as in Vulkan.

Fixes #65
Dawn change: https://dawn-review.googlesource.com/c/dawn/+/204734