### PR TITLE
Add unorm10-10-10-2 vertex format

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -838,6 +838,7 @@ typedef enum WGPUVertexFormat {
     WGPUVertexFormat_Sint32x2 = 0x0000001C,
     WGPUVertexFormat_Sint32x3 = 0x0000001D,
     WGPUVertexFormat_Sint32x4 = 0x0000001E,
+    WGPUVertexFormat_Unorm10_10_10_2 = 0x0000001F,
     WGPUVertexFormat_Force32 = 0x7FFFFFFF
 } WGPUVertexFormat WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1295,6 +1295,9 @@ enums:
       - name: sint32x4
         doc: |
           TODO
+      - name: unorm10__10__10__2
+        doc: |
+          TODO
   - name: vertex_step_mode
     doc: |
       TODO


### PR DESCRIPTION
In order to make progress on https://github.com/webgpu-native/webgpu-headers/pull/321, this PR supersedes it by adding unorm10-10-10-2 vertex format to webgpu.yml.

Related to https://github.com/gpuweb/gpuweb/issues/4275

FYI @munrocket