### PR TITLE
Add usage field to WGPUTextureViewDescriptor

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1581,6 +1581,7 @@ typedef struct WGPUTextureViewDescriptor {
     uint32_t baseArrayLayer;
     uint32_t arrayLayerCount;
     WGPUTextureAspect aspect;
+    WGPUTextureUsageFlags usage;
 } WGPUTextureViewDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUVertexAttribute {

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -2957,6 +2957,10 @@ structs:
         doc: |
           TODO
         type: enum.texture_aspect
+      - name: usage
+        doc: |
+          TODO
+        type: bitflag.texture_usage
   - name: vertex_attribute
     doc: |
       TODO


### PR DESCRIPTION
Adds the usage field to WGPUTextureViewDescriptor for the WebGPU spec change  made in https://github.com/gpuweb/gpuweb/pull/4746