### PR TITLE
Remove maxInterStageShaderComponents

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1221,7 +1221,6 @@ typedef struct WGPULimits {
     uint64_t maxBufferSize;
     uint32_t maxVertexAttributes;
     uint32_t maxVertexBufferArrayStride;
-    uint32_t maxInterStageShaderComponents;
     uint32_t maxInterStageShaderVariables;
     uint32_t maxColorAttachments;
     uint32_t maxColorAttachmentBytesPerSample;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -2122,10 +2122,6 @@ structs:
         doc: |
           TODO
         type: uint32
-      - name: max_inter_stage_shader_components
-        doc: |
-          TODO
-        type: uint32
       - name: max_inter_stage_shader_variables
         doc: |
           TODO


### PR DESCRIPTION
Following the removal of maxInterStageShaderComponents in WebGPU spec at https://github.com/gpuweb/gpuweb/pull/4783/, this PR updates webgpu-headers accordingly.

FIX https://github.com/webgpu-native/webgpu-headers/issues/328

@kainino0x Please review