### PR TITLE
Add WGPU_MAKE_INIT_STRUCT and WGPUStringView

### DIFF
--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -65,6 +65,21 @@
 #include "webgpu.h"
 {{end}}
 
+{{- if eq .Name "webgpu"}}
+#define WGPU_COMMA ,
+#if defined(__cplusplus)
+#  if __cplusplus >= 201103L
+#    define WGPU_MAKE_INIT_STRUCT(type, value) (type value)
+#  else
+#    define WGPU_MAKE_INIT_STRUCT(type, value) value
+#  endif
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#  define WGPU_MAKE_INIT_STRUCT(type, value) ((type) value)
+#else
+#  define WGPU_MAKE_INIT_STRUCT(type, value) value
+#endif
+{{end}}
+
 /**
  * \defgroup Constants
  * \brief Constants.
@@ -220,6 +235,34 @@ typedef struct WGPUChainedStructOut {
  *
  * @{
  */
+
+/**
+ * Nullable value defining a pointer+length view into a string.
+ *
+ * Values passed into the API may use the special length value @ref WGPU_STRLEN
+ * to indicate a null-terminated string.
+ * Non-null values passed out of the API (for example as callback arguments)
+ * always provide an explicit length and **may or may not be null-terminated**.
+ *
+ * Some inputs to the API accept null values. Those which do not accept null
+ * values "default" to the empty string when null values are passed.
+ *
+ * Values are encoded as follows:
+ * - `{NULL, WGPU_STRLEN}`: the null value.
+ * - `{non_null_pointer, WGPU_STRLEN}`: a null-terminated string view.
+ * - `{any, 0}`: the empty string.
+ * - `{NULL, non_zero_length}`: not allowed (null dereference).
+ * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view.
+ */
+typedef struct WGPUStringView {
+    char const * WGPU_NULLABLE data;
+    size_t length;
+} WGPUStringView;
+
+#define WGPU_STRING_VIEW_INIT WGPU_MAKE_INIT_STRUCT(WGPUStringView, { \
+    /*.data=*/NULL WGPU_COMMA \
+    /*.length=*/WGPU_STRLEN WGPU_COMMA \
+})
 
  /**
  * \defgroup WGPUCallbackInfo

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -253,6 +253,9 @@ typedef struct WGPUChainedStructOut {
  * - `{any, 0}`: the empty string.
  * - `{NULL, non_zero_length}`: not allowed (null dereference).
  * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view.
+ *
+ * To format explicitly-sized strings with `printf`, use `%.*s`
+ * (`%s` with a "precision" argument `.*` specifying a max length).
  */
 typedef struct WGPUStringView {
     char const * WGPU_NULLABLE data;

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -237,7 +237,7 @@ typedef struct WGPUChainedStructOut {
  */
 
 /**
- * Nullable value defining a pointer+length view into a string.
+ * Nullable value defining a pointer+length view into a UTF-8 encoded string.
  *
  * Values passed into the API may use the special length value @ref WGPU_STRLEN
  * to indicate a null-terminated string.

--- a/webgpu.h
+++ b/webgpu.h
@@ -55,6 +55,19 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#define WGPU_COMMA ,
+#if defined(__cplusplus)
+#  if __cplusplus >= 201103L
+#    define WGPU_MAKE_INIT_STRUCT(type, value) (type value)
+#  else
+#    define WGPU_MAKE_INIT_STRUCT(type, value) value
+#  endif
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#  define WGPU_MAKE_INIT_STRUCT(type, value) ((type) value)
+#else
+#  define WGPU_MAKE_INIT_STRUCT(type, value) value
+#endif
+
 
 /**
  * \defgroup Constants
@@ -997,6 +1010,34 @@ typedef struct WGPUChainedStructOut {
  *
  * @{
  */
+
+/**
+ * Nullable value defining a pointer+length view into a string.
+ *
+ * Values passed into the API may use the special length value @ref WGPU_STRLEN
+ * to indicate a null-terminated string.
+ * Non-null values passed out of the API (for example as callback arguments)
+ * always provide an explicit length and **may or may not be null-terminated**.
+ *
+ * Some inputs to the API accept null values. Those which do not accept null
+ * values "default" to the empty string when null values are passed.
+ *
+ * Values are encoded as follows:
+ * - `{NULL, WGPU_STRLEN}`: the null value.
+ * - `{non_null_pointer, WGPU_STRLEN}`: a null-terminated string view.
+ * - `{any, 0}`: the empty string.
+ * - `{NULL, non_zero_length}`: not allowed (null dereference).
+ * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view.
+ */
+typedef struct WGPUStringView {
+    char const * WGPU_NULLABLE data;
+    size_t length;
+} WGPUStringView;
+
+#define WGPU_STRING_VIEW_INIT WGPU_MAKE_INIT_STRUCT(WGPUStringView, { \
+    /*.data=*/NULL WGPU_COMMA \
+    /*.length=*/WGPU_STRLEN WGPU_COMMA \
+})
 
  /**
  * \defgroup WGPUCallbackInfo

--- a/webgpu.h
+++ b/webgpu.h
@@ -1012,7 +1012,7 @@ typedef struct WGPUChainedStructOut {
  */
 
 /**
- * Nullable value defining a pointer+length view into a string.
+ * Nullable value defining a pointer+length view into a UTF-8 encoded string.
  *
  * Values passed into the API may use the special length value @ref WGPU_STRLEN
  * to indicate a null-terminated string.
@@ -1028,6 +1028,9 @@ typedef struct WGPUChainedStructOut {
  * - `{any, 0}`: the empty string.
  * - `{NULL, non_zero_length}`: not allowed (null dereference).
  * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view.
+ *
+ * To format explicitly-sized strings with `printf`, use `%.*s`
+ * (`%s` with a "precision" argument `.*` specifying a max length).
  */
 typedef struct WGPUStringView {
     char const * WGPU_NULLABLE data;


### PR DESCRIPTION
This is basically copied from Dawn except:
- Use `NULL` instead of `nullptr` (`nullptr` was added in C23)
- Put `WGPU_NULLABLE` in the correct place per #190 so we don't forget about it later
- Documentation! I added a few important things we did not discuss:
  - Places that accept non-nullable stringviews simply default to empty string (e.g. labels)
  - Outputs from the API always use explicit-length stringviews which may or may not be null terminated

Issue: #170 (not fixed yet, this is just the start)
(dawn bug https://crbug.com/42241188)