### PR TITLE
Add missing WGPU_STRLEN and document some more string things

### DIFF
--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -252,7 +252,8 @@ typedef struct WGPUChainedStructOut {
  * - `{non_null_pointer, WGPU_STRLEN}`: a null-terminated string view.
  * - `{any, 0}`: the empty string.
  * - `{NULL, non_zero_length}`: not allowed (null dereference).
- * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view.
+ * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view with
+ *   size `non_zero_length` (in bytes).
  *
  * To format explicitly-sized strings with `printf`, use `%.*s`
  * (`%s` with a "precision" argument `.*` specifying a max length).
@@ -262,6 +263,13 @@ typedef struct WGPUStringView {
     size_t length;
 } WGPUStringView;
 
+/**
+ * Sentinel value used in @link WGPUStringView to indicate that the pointer
+ * is to a null-terminated string, rather than an explicitly-sized string.
+ */
+#define WGPU_STRLEN
+
+/** Default value definition for @link WGPUStringView. */
 #define WGPU_STRING_VIEW_INIT WGPU_MAKE_INIT_STRUCT(WGPUStringView, { \
     /*.data=*/NULL WGPU_COMMA \
     /*.length=*/WGPU_STRLEN WGPU_COMMA \

--- a/tests/compile/main.inl
+++ b/tests/compile/main.inl
@@ -3,6 +3,10 @@
 // Compile-test the instantiation of all of the macros, and spot-check types
 int main(void) {
     {
+        WGPUStringView s = WGPU_STRING_VIEW_INIT;
+        s.length = WGPU_STRLEN;
+        (void) s;
+    {
         WGPUTextureViewDescriptor a;
         a.mipLevelCount = WGPU_MIP_LEVEL_COUNT_UNDEFINED;
         a.arrayLayerCount = WGPU_ARRAY_LAYER_COUNT_UNDEFINED;

--- a/webgpu.h
+++ b/webgpu.h
@@ -1027,7 +1027,8 @@ typedef struct WGPUChainedStructOut {
  * - `{non_null_pointer, WGPU_STRLEN}`: a null-terminated string view.
  * - `{any, 0}`: the empty string.
  * - `{NULL, non_zero_length}`: not allowed (null dereference).
- * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view.
+ * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view with
+ *   size `non_zero_length` (in bytes).
  *
  * To format explicitly-sized strings with `printf`, use `%.*s`
  * (`%s` with a "precision" argument `.*` specifying a max length).
@@ -1037,6 +1038,13 @@ typedef struct WGPUStringView {
     size_t length;
 } WGPUStringView;
 
+/**
+ * Sentinel value used in @link WGPUStringView to indicate that the pointer
+ * is to a null-terminated string, rather than an explicitly-sized string.
+ */
+#define WGPU_STRLEN
+
+/** Default value definition for @link WGPUStringView. */
 #define WGPU_STRING_VIEW_INIT WGPU_MAKE_INIT_STRUCT(WGPUStringView, { \
     /*.data=*/NULL WGPU_COMMA \
     /*.length=*/WGPU_STRLEN WGPU_COMMA \


### PR DESCRIPTION
I should note that `WGPU_STRLEN` is added directly to the template, like `WGPUStringView` and `WGPU_STRING_VIEW_INIT`, because I figure these won't be exposed directly by bindings to most other languages, since most languages have their own string/string view types.

@rajveermalviya Could you also take a moment to review the semantics I previously documented for WGPUStringView? In particular, `Those which do not accept null values "default" to the empty string when null values are passed.` (Sorry I didn't cc you when I was adding it.)