### PR TITLE
Use WGPUStringView everywhere

### DIFF
--- a/doc/articles/Asynchronous Operations.md
+++ b/doc/articles/Asynchronous Operations.md
@@ -13,7 +13,7 @@ All asynchronous operations start when the application calls an asynchronous web
    ```c
    typedef void (*WGPUBufferMapCallback)(
        WGPUMapAsyncStatus status,
-       char const * message,
+       WGPUStringView message,
        WGPU_NULLABLE void* userdata1,
        WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
    ```

--- a/doc/articles/Surfaces.md
+++ b/doc/articles/Surfaces.md
@@ -34,7 +34,7 @@ WGPUSurfaceSourceWindowsHWND hwndDesc = {
 };
 WGPUSurfaceDescriptor desc {
     .nextInChain = &hwndDesc.chain,
-    .label = "Main window",
+    .label = {.data = "Main window", .length = WGPU_STRLEN},
 };
 WGPUSurface surface = wgpuInstanceCreateSurface(myInstance, &desc);
 ```
@@ -151,7 +151,7 @@ WGPUTextureDescriptor GetSurfaceEquivalentTextureDescriptor(const WGPUSurfaceCon
 
         // Parameters that cannot be changed.
         .nextInChain = nullptr,
-        .label = "",
+        .label = {.data = "", .length = WGPU_STRLEN},
         .dimension = WGPUTextureDimension_2D,
         .sampleCount = 1,
         .mipLevelCount = 1,

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -309,7 +309,7 @@ typedef struct WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} {
     WGPUChainedStructOut chain;
 {{-   end}}
 {{-   range $memberIndex, $_ := .Members}}
-    {{- MComment .Doc 4 }}
+    {{- MCommentWithTypeInfo .Doc .Type 4 }}
     {{  StructMember $struct $memberIndex}}
 {{-   end}}
 } WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} WGPU_STRUCTURE_ATTRIBUTE;
@@ -335,7 +335,7 @@ typedef {{FunctionReturns .}} (*WGPUProc{{.Name | PascalCase}}{{$.ExtSuffix}})({
  * Proc pointer type for @ref wgpuGetProcAddress:
  * > @copydoc wgpuGetProcAddress
  */
-typedef WGPUProc (*WGPUProcGetProcAddress)(char const * procName) WGPU_FUNCTION_ATTRIBUTE;
+typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUStringView procName) WGPU_FUNCTION_ATTRIBUTE;
 {{  end}}
 
 {{- range $object := .Objects}}
@@ -381,7 +381,7 @@ WGPU_EXPORT {{FunctionReturns .}} wgpu{{.Name | PascalCase}}{{$.ExtSuffix}}({{Fu
  * Returns the "procedure address" (function pointer) of the named function.
  * The result must be cast to the appropriate proc pointer type.
  */
-WGPU_EXPORT WGPUProc wgpuGetProcAddress(char const * procName) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT WGPUProc wgpuGetProcAddress(WGPUStringView procName) WGPU_FUNCTION_ATTRIBUTE;
 {{  end}}
 
 /** @} */

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -97,8 +97,7 @@
 /** @} */
 
 /**
- * \defgroup Typedefs
- * \brief Utility typedefs.
+ * \defgroup UtilityTypes Utility Types
  *
  * @{
  */
@@ -106,6 +105,44 @@
 {{- if eq .Name "webgpu"}}
 typedef uint64_t WGPUFlags;
 typedef uint32_t WGPUBool;
+
+/**
+ * Nullable value defining a pointer+length view into a UTF-8 encoded string.
+ *
+ * Values passed into the API may use the special length value @ref WGPU_STRLEN
+ * to indicate a null-terminated string.
+ * Non-null values passed out of the API (for example as callback arguments)
+ * always provide an explicit length and **may or may not be null-terminated**.
+ *
+ * Some inputs to the API accept null values. Those which do not accept null
+ * values "default" to the empty string when null values are passed.
+ *
+ * Values are encoded as follows:
+ * - `{NULL, WGPU_STRLEN}`: the null value.
+ * - `{non_null_pointer, WGPU_STRLEN}`: a null-terminated string view.
+ * - `{any, 0}`: the empty string.
+ * - `{NULL, non_zero_length}`: not allowed (null dereference).
+ * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view with
+ *   size `non_zero_length` (in bytes).
+ *
+ * To format explicitly-sized strings with `printf`, use `%.*s`
+ * (`%s` with a "precision" argument `.*` specifying a max length).
+ */
+typedef struct WGPUStringView {
+    char const * WGPU_NULLABLE data;
+    size_t length;
+} WGPUStringView;
+
+/**
+ * Sentinel value used in @ref WGPUStringView to indicate that the pointer
+ * is to a null-terminated string, rather than an explicitly-sized string.
+ */
+#define WGPU_STRLEN SIZE_MAX
+
+#define WGPU_STRING_VIEW_INIT _wgpu_MAKE_INIT_STRUCT(WGPUStringView, { \
+    /*.data=*/NULL _wgpu_COMMA \
+    /*.length=*/WGPU_STRLEN _wgpu_COMMA \
+})
 {{  end}}
 {{- range .Typedefs}}
 {{-   MComment .Doc 0}}
@@ -174,7 +211,7 @@ typedef enum WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} {
 
 /**
  * \defgroup Bitflags
- * \brief Enum used as bit flags.
+ * \brief Type and constant definitions for bitflag types.
  *
  * @{
  */
@@ -235,44 +272,6 @@ typedef struct WGPUChainedStructOut {
  *
  * @{
  */
-
-/**
- * Nullable value defining a pointer+length view into a UTF-8 encoded string.
- *
- * Values passed into the API may use the special length value @ref WGPU_STRLEN
- * to indicate a null-terminated string.
- * Non-null values passed out of the API (for example as callback arguments)
- * always provide an explicit length and **may or may not be null-terminated**.
- *
- * Some inputs to the API accept null values. Those which do not accept null
- * values "default" to the empty string when null values are passed.
- *
- * Values are encoded as follows:
- * - `{NULL, WGPU_STRLEN}`: the null value.
- * - `{non_null_pointer, WGPU_STRLEN}`: a null-terminated string view.
- * - `{any, 0}`: the empty string.
- * - `{NULL, non_zero_length}`: not allowed (null dereference).
- * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view with
- *   size `non_zero_length` (in bytes).
- *
- * To format explicitly-sized strings with `printf`, use `%.*s`
- * (`%s` with a "precision" argument `.*` specifying a max length).
- */
-typedef struct WGPUStringView {
-    char const * WGPU_NULLABLE data;
-    size_t length;
-} WGPUStringView;
-
-/**
- * Sentinel value used in @link WGPUStringView to indicate that the pointer
- * is to a null-terminated string, rather than an explicitly-sized string.
- */
-#define WGPU_STRLEN SIZE_MAX
-
-#define WGPU_STRING_VIEW_INIT _wgpu_MAKE_INIT_STRUCT(WGPUStringView, { \
-    /*.data=*/NULL _wgpu_COMMA \
-    /*.length=*/WGPU_STRLEN _wgpu_COMMA \
-})
 
  /**
  * \defgroup WGPUCallbackInfo

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -52,6 +52,25 @@ func (g *Generator) Gen(dst io.Writer) error {
 				}
 				return Comment(strings.TrimSpace(s), CommentTypeMultiLine, indent, true)
 			},
+			"MCommentWithTypeInfo": func(srcDoc string, typ string, indent int) string {
+				var s string
+				srcDoc = strings.TrimSpace(srcDoc)
+				if srcDoc != "" && srcDoc != "TODO" {
+					s += srcDoc
+				}
+			
+				switch typ {
+				case "nullable_string":
+					s += "\n\nThis string is nullable."
+				case "string_with_default_empty":
+					s += "\n\nIf the null value is passed, this defaults to the empty string."
+				case "out_string":
+					s += "\n\nThis output string is guaranteed to always be explicitly sized. The data may or may not also be null-terminated."
+				default:
+					s += ""
+				}
+				return Comment(strings.TrimSpace(s), CommentTypeMultiLine, indent, true)
+			},
 			"ConstantCase": ConstantCase,
 			"PascalCase":   PascalCase,
 			"CamelCase":    CamelCase,
@@ -141,8 +160,8 @@ func (g *Generator) CType(typ string, pointerType PointerType, suffix string) st
 	switch typ {
 	case "bool":
 		return appendModifiers("WGPUBool", pointerType)
-	case "string":
-		return appendModifiers("char", PointerTypeImmutable)
+	case "nullable_string", "string_with_default_empty", "out_string":
+		return "WGPUStringView"
 	case "uint16":
 		return appendModifiers("uint16_t", pointerType)
 	case "uint32":

--- a/schema.json
+++ b/schema.json
@@ -33,7 +33,9 @@
             "enum": [
                 "c_void",
                 "bool",
-                "string",
+                "nullable_string",
+                "string_with_default_empty",
+                "out_string",
                 "uint16",
                 "uint32",
                 "uint64",

--- a/webgpu.h
+++ b/webgpu.h
@@ -89,13 +89,50 @@
 /** @} */
 
 /**
- * \defgroup Typedefs
- * \brief Utility typedefs.
+ * \defgroup UtilityTypes Utility Types
  *
  * @{
  */
 typedef uint64_t WGPUFlags;
 typedef uint32_t WGPUBool;
+
+/**
+ * Nullable value defining a pointer+length view into a UTF-8 encoded string.
+ *
+ * Values passed into the API may use the special length value @ref WGPU_STRLEN
+ * to indicate a null-terminated string.
+ * Non-null values passed out of the API (for example as callback arguments)
+ * always provide an explicit length and **may or may not be null-terminated**.
+ *
+ * Some inputs to the API accept null values. Those which do not accept null
+ * values "default" to the empty string when null values are passed.
+ *
+ * Values are encoded as follows:
+ * - `{NULL, WGPU_STRLEN}`: the null value.
+ * - `{non_null_pointer, WGPU_STRLEN}`: a null-terminated string view.
+ * - `{any, 0}`: the empty string.
+ * - `{NULL, non_zero_length}`: not allowed (null dereference).
+ * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view with
+ *   size `non_zero_length` (in bytes).
+ *
+ * To format explicitly-sized strings with `printf`, use `%.*s`
+ * (`%s` with a "precision" argument `.*` specifying a max length).
+ */
+typedef struct WGPUStringView {
+    char const * WGPU_NULLABLE data;
+    size_t length;
+} WGPUStringView;
+
+/**
+ * Sentinel value used in @ref WGPUStringView to indicate that the pointer
+ * is to a null-terminated string, rather than an explicitly-sized string.
+ */
+#define WGPU_STRLEN SIZE_MAX
+
+#define WGPU_STRING_VIEW_INIT _wgpu_MAKE_INIT_STRUCT(WGPUStringView, { \
+    /*.data=*/NULL _wgpu_COMMA \
+    /*.length=*/WGPU_STRLEN _wgpu_COMMA \
+})
 
 
 /** @} */
@@ -917,7 +954,7 @@ typedef enum WGPUWaitStatus {
 
 /**
  * \defgroup Bitflags
- * \brief Enum used as bit flags.
+ * \brief Type and constant definitions for bitflag types.
  *
  * @{
  */
@@ -1010,44 +1047,6 @@ typedef struct WGPUChainedStructOut {
  *
  * @{
  */
-
-/**
- * Nullable value defining a pointer+length view into a UTF-8 encoded string.
- *
- * Values passed into the API may use the special length value @ref WGPU_STRLEN
- * to indicate a null-terminated string.
- * Non-null values passed out of the API (for example as callback arguments)
- * always provide an explicit length and **may or may not be null-terminated**.
- *
- * Some inputs to the API accept null values. Those which do not accept null
- * values "default" to the empty string when null values are passed.
- *
- * Values are encoded as follows:
- * - `{NULL, WGPU_STRLEN}`: the null value.
- * - `{non_null_pointer, WGPU_STRLEN}`: a null-terminated string view.
- * - `{any, 0}`: the empty string.
- * - `{NULL, non_zero_length}`: not allowed (null dereference).
- * - `{non_null_pointer, non_zero_length}`: an explictly-sized string view with
- *   size `non_zero_length` (in bytes).
- *
- * To format explicitly-sized strings with `printf`, use `%.*s`
- * (`%s` with a "precision" argument `.*` specifying a max length).
- */
-typedef struct WGPUStringView {
-    char const * WGPU_NULLABLE data;
-    size_t length;
-} WGPUStringView;
-
-/**
- * Sentinel value used in @link WGPUStringView to indicate that the pointer
- * is to a null-terminated string, rather than an explicitly-sized string.
- */
-#define WGPU_STRLEN SIZE_MAX
-
-#define WGPU_STRING_VIEW_INIT _wgpu_MAKE_INIT_STRUCT(WGPUStringView, { \
-    /*.data=*/NULL _wgpu_COMMA \
-    /*.length=*/WGPU_STRLEN _wgpu_COMMA \
-})
 
  /**
  * \defgroup WGPUCallbackInfo

--- a/webgpu.h
+++ b/webgpu.h
@@ -1009,16 +1009,16 @@ typedef void (*WGPUProc)(void) WGPU_FUNCTION_ATTRIBUTE;
  *
  * @{
  */
-typedef void (*WGPUBufferMapCallback)(WGPUMapAsyncStatus status, char const * message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUBufferMapCallback)(WGPUMapAsyncStatus status, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUCompilationInfoCallback)(WGPUCompilationInfoRequestStatus status, struct WGPUCompilationInfo const * compilationInfo, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUCreateComputePipelineAsyncCallback)(WGPUCreatePipelineAsyncStatus status, WGPUComputePipeline pipeline, char const * message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUCreateRenderPipelineAsyncCallback)(WGPUCreatePipelineAsyncStatus status, WGPURenderPipeline pipeline, char const * message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUDeviceLostCallback)(WGPUDevice const * device, WGPUDeviceLostReason reason, char const * message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUPopErrorScopeCallback)(WGPUPopErrorScopeStatus status, WGPUErrorType type, char const * message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUCreateComputePipelineAsyncCallback)(WGPUCreatePipelineAsyncStatus status, WGPUComputePipeline pipeline, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUCreateRenderPipelineAsyncCallback)(WGPUCreatePipelineAsyncStatus status, WGPURenderPipeline pipeline, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUDeviceLostCallback)(WGPUDevice const * device, WGPUDeviceLostReason reason, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUPopErrorScopeCallback)(WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUQueueWorkDoneCallback)(WGPUQueueWorkDoneStatus status, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPURequestAdapterCallback)(WGPURequestAdapterStatus status, WGPUAdapter adapter, char const * message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPURequestDeviceCallback)(WGPURequestDeviceStatus status, WGPUDevice device, char const * message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUUncapturedErrorCallback)(WGPUDevice const * device, WGPUErrorType type, char const * message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPURequestAdapterCallback)(WGPURequestAdapterStatus status, WGPUAdapter adapter, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPURequestDeviceCallback)(WGPURequestDeviceStatus status, WGPUDevice device, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUUncapturedErrorCallback)(WGPUDevice const * device, WGPUErrorType type, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
 
 /** @} */
 /**
@@ -1128,10 +1128,22 @@ typedef struct WGPUUncapturedErrorCallbackInfo {
 
 typedef struct WGPUAdapterInfo {
     WGPUChainedStructOut * nextInChain;
-    char const * vendor;
-    char const * architecture;
-    char const * device;
-    char const * description;
+    /**
+     * This output string is guaranteed to always be explicitly sized. The data may or may not also be null-terminated.
+     */
+    WGPUStringView vendor;
+    /**
+     * This output string is guaranteed to always be explicitly sized. The data may or may not also be null-terminated.
+     */
+    WGPUStringView architecture;
+    /**
+     * This output string is guaranteed to always be explicitly sized. The data may or may not also be null-terminated.
+     */
+    WGPUStringView device;
+    /**
+     * This output string is guaranteed to always be explicitly sized. The data may or may not also be null-terminated.
+     */
+    WGPUStringView description;
     WGPUBackendType backendType;
     WGPUAdapterType adapterType;
     uint32_t vendorID;
@@ -1163,7 +1175,10 @@ typedef struct WGPUBufferBindingLayout {
 
 typedef struct WGPUBufferDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     WGPUBufferUsage usage;
     uint64_t size;
     WGPUBool mappedAtCreation;
@@ -1178,17 +1193,26 @@ typedef struct WGPUColor {
 
 typedef struct WGPUCommandBufferDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
 } WGPUCommandBufferDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUCommandEncoderDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
 } WGPUCommandEncoderDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUCompilationMessage {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * message;
+    /**
+     * This output string is guaranteed to always be explicitly sized. The data may or may not also be null-terminated.
+     */
+    WGPUStringView message;
     WGPUCompilationMessageType type;
     uint64_t lineNum;
     uint64_t linePos;
@@ -1207,7 +1231,10 @@ typedef struct WGPUComputePassTimestampWrites {
 
 typedef struct WGPUConstantEntry {
     WGPUChainedStruct const * nextInChain;
-    char const * key;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView key;
     double value;
 } WGPUConstantEntry WGPU_STRUCTURE_ATTRIBUTE;
 
@@ -1291,7 +1318,10 @@ typedef struct WGPUOrigin3D {
 
 typedef struct WGPUPipelineLayoutDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     size_t bindGroupLayoutCount;
     WGPUBindGroupLayout const * bindGroupLayouts;
 } WGPUPipelineLayoutDescriptor WGPU_STRUCTURE_ATTRIBUTE;
@@ -1307,24 +1337,36 @@ typedef struct WGPUPrimitiveState {
 
 typedef struct WGPUQuerySetDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     WGPUQueryType type;
     uint32_t count;
 } WGPUQuerySetDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUQueueDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
 } WGPUQueueDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderBundleDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
 } WGPURenderBundleDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderBundleEncoderDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     size_t colorFormatCount;
     WGPUTextureFormat const * colorFormats;
     WGPUTextureFormat depthStencilFormat;
@@ -1371,7 +1413,10 @@ typedef struct WGPUSamplerBindingLayout {
 
 typedef struct WGPUSamplerDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     WGPUAddressMode addressModeU;
     WGPUAddressMode addressModeV;
     WGPUAddressMode addressModeW;
@@ -1386,7 +1431,10 @@ typedef struct WGPUSamplerDescriptor {
 
 typedef struct WGPUShaderModuleDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
 } WGPUShaderModuleDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUShaderSourceSPIRV {
@@ -1397,7 +1445,10 @@ typedef struct WGPUShaderSourceSPIRV {
 
 typedef struct WGPUShaderSourceWGSL {
     WGPUChainedStruct chain;
-    char const * code;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView code;
 } WGPUShaderSourceWGSL WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUStencilFaceState {
@@ -1499,8 +1550,10 @@ typedef struct WGPUSurfaceDescriptor {
     WGPUChainedStruct const * nextInChain;
     /**
      * Label used to refer to the object.
+     *
+     * If the null value is passed, this defaults to the empty string.
      */
-    WGPU_NULLABLE char const * label;
+    WGPUStringView label;
 } WGPUSurfaceDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 /**
@@ -1617,7 +1670,10 @@ typedef struct WGPUTextureDataLayout {
 
 typedef struct WGPUTextureViewDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     WGPUTextureFormat format;
     WGPUTextureViewDimension dimension;
     uint32_t baseMipLevel;
@@ -1636,7 +1692,10 @@ typedef struct WGPUVertexAttribute {
 
 typedef struct WGPUBindGroupDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     WGPUBindGroupLayout layout;
     size_t entryCount;
     WGPUBindGroupEntry const * entries;
@@ -1665,7 +1724,10 @@ typedef struct WGPUCompilationInfo {
 
 typedef struct WGPUComputePassDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     WGPU_NULLABLE WGPUComputePassTimestampWrites const * timestampWrites;
 } WGPUComputePassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
@@ -1722,7 +1784,10 @@ typedef struct WGPUInstanceDescriptor {
 typedef struct WGPUProgrammableStageDescriptor {
     WGPUChainedStruct const * nextInChain;
     WGPUShaderModule module;
-    WGPU_NULLABLE char const * entryPoint;
+    /**
+     * This string is nullable.
+     */
+    WGPUStringView entryPoint;
     size_t constantCount;
     WGPUConstantEntry const * constants;
 } WGPUProgrammableStageDescriptor WGPU_STRUCTURE_ATTRIBUTE;
@@ -1749,7 +1814,10 @@ typedef struct WGPUSupportedLimits {
 
 typedef struct WGPUTextureDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     WGPUTextureUsage usage;
     WGPUTextureDimension dimension;
     WGPUExtent3D size;
@@ -1769,7 +1837,10 @@ typedef struct WGPUVertexBufferLayout {
 
 typedef struct WGPUBindGroupLayoutDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     size_t entryCount;
     WGPUBindGroupLayoutEntry const * entries;
 } WGPUBindGroupLayoutDescriptor WGPU_STRUCTURE_ATTRIBUTE;
@@ -1783,14 +1854,20 @@ typedef struct WGPUColorTargetState {
 
 typedef struct WGPUComputePipelineDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     WGPU_NULLABLE WGPUPipelineLayout layout;
     WGPUProgrammableStageDescriptor compute;
 } WGPUComputePipelineDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUDeviceDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     size_t requiredFeatureCount;
     WGPUFeatureName const * requiredFeatures;
     WGPU_NULLABLE WGPURequiredLimits const * requiredLimits;
@@ -1801,7 +1878,10 @@ typedef struct WGPUDeviceDescriptor {
 
 typedef struct WGPURenderPassDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     size_t colorAttachmentCount;
     WGPURenderPassColorAttachment const * colorAttachments;
     WGPU_NULLABLE WGPURenderPassDepthStencilAttachment const * depthStencilAttachment;
@@ -1812,7 +1892,10 @@ typedef struct WGPURenderPassDescriptor {
 typedef struct WGPUVertexState {
     WGPUChainedStruct const * nextInChain;
     WGPUShaderModule module;
-    WGPU_NULLABLE char const * entryPoint;
+    /**
+     * This string is nullable.
+     */
+    WGPUStringView entryPoint;
     size_t constantCount;
     WGPUConstantEntry const * constants;
     size_t bufferCount;
@@ -1822,7 +1905,10 @@ typedef struct WGPUVertexState {
 typedef struct WGPUFragmentState {
     WGPUChainedStruct const * nextInChain;
     WGPUShaderModule module;
-    WGPU_NULLABLE char const * entryPoint;
+    /**
+     * This string is nullable.
+     */
+    WGPUStringView entryPoint;
     size_t constantCount;
     WGPUConstantEntry const * constants;
     size_t targetCount;
@@ -1831,7 +1917,10 @@ typedef struct WGPUFragmentState {
 
 typedef struct WGPURenderPipelineDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    /**
+     * If the null value is passed, this defaults to the empty string.
+     */
+    WGPUStringView label;
     WGPU_NULLABLE WGPUPipelineLayout layout;
     WGPUVertexState vertex;
     WGPUPrimitiveState primitive;
@@ -1862,7 +1951,7 @@ typedef void (*WGPUProcGetInstanceFeatures)(WGPUInstanceFeatures * features) WGP
  * Proc pointer type for @ref wgpuGetProcAddress:
  * > @copydoc wgpuGetProcAddress
  */
-typedef WGPUProc (*WGPUProcGetProcAddress)(char const * procName) WGPU_FUNCTION_ATTRIBUTE;
+typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUStringView procName) WGPU_FUNCTION_ATTRIBUTE;
 
 // Procs of Adapter
 /**
@@ -1913,7 +2002,7 @@ typedef void (*WGPUProcAdapterInfoFreeMembers)(WGPUAdapterInfo adapterInfo) WGPU
  * Proc pointer type for @ref wgpuBindGroupSetLabel:
  * > @copydoc wgpuBindGroupSetLabel
  */
-typedef void (*WGPUProcBindGroupSetLabel)(WGPUBindGroup bindGroup, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcBindGroupSetLabel)(WGPUBindGroup bindGroup, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuBindGroupAddRef.
  * > @copydoc wgpuBindGroupAddRef
@@ -1930,7 +2019,7 @@ typedef void (*WGPUProcBindGroupRelease)(WGPUBindGroup bindGroup) WGPU_FUNCTION_
  * Proc pointer type for @ref wgpuBindGroupLayoutSetLabel:
  * > @copydoc wgpuBindGroupLayoutSetLabel
  */
-typedef void (*WGPUProcBindGroupLayoutSetLabel)(WGPUBindGroupLayout bindGroupLayout, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcBindGroupLayoutSetLabel)(WGPUBindGroupLayout bindGroupLayout, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuBindGroupLayoutAddRef.
  * > @copydoc wgpuBindGroupLayoutAddRef
@@ -1982,7 +2071,7 @@ typedef WGPUFuture (*WGPUProcBufferMapAsync)(WGPUBuffer buffer, WGPUMapMode mode
  * Proc pointer type for @ref wgpuBufferSetLabel:
  * > @copydoc wgpuBufferSetLabel
  */
-typedef void (*WGPUProcBufferSetLabel)(WGPUBuffer buffer, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcBufferSetLabel)(WGPUBuffer buffer, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuBufferUnmap:
  * > @copydoc wgpuBufferUnmap
@@ -2004,7 +2093,7 @@ typedef void (*WGPUProcBufferRelease)(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE
  * Proc pointer type for @ref wgpuCommandBufferSetLabel:
  * > @copydoc wgpuCommandBufferSetLabel
  */
-typedef void (*WGPUProcCommandBufferSetLabel)(WGPUCommandBuffer commandBuffer, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcCommandBufferSetLabel)(WGPUCommandBuffer commandBuffer, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuCommandBufferAddRef.
  * > @copydoc wgpuCommandBufferAddRef
@@ -2061,7 +2150,7 @@ typedef WGPUCommandBuffer (*WGPUProcCommandEncoderFinish)(WGPUCommandEncoder com
  * Proc pointer type for @ref wgpuCommandEncoderInsertDebugMarker:
  * > @copydoc wgpuCommandEncoderInsertDebugMarker
  */
-typedef void (*WGPUProcCommandEncoderInsertDebugMarker)(WGPUCommandEncoder commandEncoder, char const * markerLabel) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcCommandEncoderInsertDebugMarker)(WGPUCommandEncoder commandEncoder, WGPUStringView markerLabel) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuCommandEncoderPopDebugGroup:
  * > @copydoc wgpuCommandEncoderPopDebugGroup
@@ -2071,7 +2160,7 @@ typedef void (*WGPUProcCommandEncoderPopDebugGroup)(WGPUCommandEncoder commandEn
  * Proc pointer type for @ref wgpuCommandEncoderPushDebugGroup:
  * > @copydoc wgpuCommandEncoderPushDebugGroup
  */
-typedef void (*WGPUProcCommandEncoderPushDebugGroup)(WGPUCommandEncoder commandEncoder, char const * groupLabel) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcCommandEncoderPushDebugGroup)(WGPUCommandEncoder commandEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuCommandEncoderResolveQuerySet:
  * > @copydoc wgpuCommandEncoderResolveQuerySet
@@ -2081,7 +2170,7 @@ typedef void (*WGPUProcCommandEncoderResolveQuerySet)(WGPUCommandEncoder command
  * Proc pointer type for @ref wgpuCommandEncoderSetLabel:
  * > @copydoc wgpuCommandEncoderSetLabel
  */
-typedef void (*WGPUProcCommandEncoderSetLabel)(WGPUCommandEncoder commandEncoder, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcCommandEncoderSetLabel)(WGPUCommandEncoder commandEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuCommandEncoderWriteTimestamp:
  * > @copydoc wgpuCommandEncoderWriteTimestamp
@@ -2118,7 +2207,7 @@ typedef void (*WGPUProcComputePassEncoderEnd)(WGPUComputePassEncoder computePass
  * Proc pointer type for @ref wgpuComputePassEncoderInsertDebugMarker:
  * > @copydoc wgpuComputePassEncoderInsertDebugMarker
  */
-typedef void (*WGPUProcComputePassEncoderInsertDebugMarker)(WGPUComputePassEncoder computePassEncoder, char const * markerLabel) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcComputePassEncoderInsertDebugMarker)(WGPUComputePassEncoder computePassEncoder, WGPUStringView markerLabel) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuComputePassEncoderPopDebugGroup:
  * > @copydoc wgpuComputePassEncoderPopDebugGroup
@@ -2128,7 +2217,7 @@ typedef void (*WGPUProcComputePassEncoderPopDebugGroup)(WGPUComputePassEncoder c
  * Proc pointer type for @ref wgpuComputePassEncoderPushDebugGroup:
  * > @copydoc wgpuComputePassEncoderPushDebugGroup
  */
-typedef void (*WGPUProcComputePassEncoderPushDebugGroup)(WGPUComputePassEncoder computePassEncoder, char const * groupLabel) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcComputePassEncoderPushDebugGroup)(WGPUComputePassEncoder computePassEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuComputePassEncoderSetBindGroup:
  * > @copydoc wgpuComputePassEncoderSetBindGroup
@@ -2138,7 +2227,7 @@ typedef void (*WGPUProcComputePassEncoderSetBindGroup)(WGPUComputePassEncoder co
  * Proc pointer type for @ref wgpuComputePassEncoderSetLabel:
  * > @copydoc wgpuComputePassEncoderSetLabel
  */
-typedef void (*WGPUProcComputePassEncoderSetLabel)(WGPUComputePassEncoder computePassEncoder, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcComputePassEncoderSetLabel)(WGPUComputePassEncoder computePassEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuComputePassEncoderSetPipeline:
  * > @copydoc wgpuComputePassEncoderSetPipeline
@@ -2165,7 +2254,7 @@ typedef WGPUBindGroupLayout (*WGPUProcComputePipelineGetBindGroupLayout)(WGPUCom
  * Proc pointer type for @ref wgpuComputePipelineSetLabel:
  * > @copydoc wgpuComputePipelineSetLabel
  */
-typedef void (*WGPUProcComputePipelineSetLabel)(WGPUComputePipeline computePipeline, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcComputePipelineSetLabel)(WGPUComputePipeline computePipeline, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuComputePipelineAddRef.
  * > @copydoc wgpuComputePipelineAddRef
@@ -2287,7 +2376,7 @@ typedef void (*WGPUProcDevicePushErrorScope)(WGPUDevice device, WGPUErrorFilter 
  * Proc pointer type for @ref wgpuDeviceSetLabel:
  * > @copydoc wgpuDeviceSetLabel
  */
-typedef void (*WGPUProcDeviceSetLabel)(WGPUDevice device, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcDeviceSetLabel)(WGPUDevice device, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuDeviceAddRef.
  * > @copydoc wgpuDeviceAddRef
@@ -2341,7 +2430,7 @@ typedef void (*WGPUProcInstanceRelease)(WGPUInstance instance) WGPU_FUNCTION_ATT
  * Proc pointer type for @ref wgpuPipelineLayoutSetLabel:
  * > @copydoc wgpuPipelineLayoutSetLabel
  */
-typedef void (*WGPUProcPipelineLayoutSetLabel)(WGPUPipelineLayout pipelineLayout, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcPipelineLayoutSetLabel)(WGPUPipelineLayout pipelineLayout, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuPipelineLayoutAddRef.
  * > @copydoc wgpuPipelineLayoutAddRef
@@ -2373,7 +2462,7 @@ typedef WGPUQueryType (*WGPUProcQuerySetGetType)(WGPUQuerySet querySet) WGPU_FUN
  * Proc pointer type for @ref wgpuQuerySetSetLabel:
  * > @copydoc wgpuQuerySetSetLabel
  */
-typedef void (*WGPUProcQuerySetSetLabel)(WGPUQuerySet querySet, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcQuerySetSetLabel)(WGPUQuerySet querySet, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuQuerySetAddRef.
  * > @copydoc wgpuQuerySetAddRef
@@ -2395,7 +2484,7 @@ typedef WGPUFuture (*WGPUProcQueueOnSubmittedWorkDone)(WGPUQueue queue, WGPUQueu
  * Proc pointer type for @ref wgpuQueueSetLabel:
  * > @copydoc wgpuQueueSetLabel
  */
-typedef void (*WGPUProcQueueSetLabel)(WGPUQueue queue, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcQueueSetLabel)(WGPUQueue queue, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuQueueSubmit:
  * > @copydoc wgpuQueueSubmit
@@ -2427,7 +2516,7 @@ typedef void (*WGPUProcQueueRelease)(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
  * Proc pointer type for @ref wgpuRenderBundleSetLabel:
  * > @copydoc wgpuRenderBundleSetLabel
  */
-typedef void (*WGPUProcRenderBundleSetLabel)(WGPURenderBundle renderBundle, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcRenderBundleSetLabel)(WGPURenderBundle renderBundle, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderBundleAddRef.
  * > @copydoc wgpuRenderBundleAddRef
@@ -2469,7 +2558,7 @@ typedef WGPURenderBundle (*WGPUProcRenderBundleEncoderFinish)(WGPURenderBundleEn
  * Proc pointer type for @ref wgpuRenderBundleEncoderInsertDebugMarker:
  * > @copydoc wgpuRenderBundleEncoderInsertDebugMarker
  */
-typedef void (*WGPUProcRenderBundleEncoderInsertDebugMarker)(WGPURenderBundleEncoder renderBundleEncoder, char const * markerLabel) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcRenderBundleEncoderInsertDebugMarker)(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView markerLabel) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderBundleEncoderPopDebugGroup:
  * > @copydoc wgpuRenderBundleEncoderPopDebugGroup
@@ -2479,7 +2568,7 @@ typedef void (*WGPUProcRenderBundleEncoderPopDebugGroup)(WGPURenderBundleEncoder
  * Proc pointer type for @ref wgpuRenderBundleEncoderPushDebugGroup:
  * > @copydoc wgpuRenderBundleEncoderPushDebugGroup
  */
-typedef void (*WGPUProcRenderBundleEncoderPushDebugGroup)(WGPURenderBundleEncoder renderBundleEncoder, char const * groupLabel) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcRenderBundleEncoderPushDebugGroup)(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderBundleEncoderSetBindGroup:
  * > @copydoc wgpuRenderBundleEncoderSetBindGroup
@@ -2494,7 +2583,7 @@ typedef void (*WGPUProcRenderBundleEncoderSetIndexBuffer)(WGPURenderBundleEncode
  * Proc pointer type for @ref wgpuRenderBundleEncoderSetLabel:
  * > @copydoc wgpuRenderBundleEncoderSetLabel
  */
-typedef void (*WGPUProcRenderBundleEncoderSetLabel)(WGPURenderBundleEncoder renderBundleEncoder, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcRenderBundleEncoderSetLabel)(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderBundleEncoderSetPipeline:
  * > @copydoc wgpuRenderBundleEncoderSetPipeline
@@ -2561,7 +2650,7 @@ typedef void (*WGPUProcRenderPassEncoderExecuteBundles)(WGPURenderPassEncoder re
  * Proc pointer type for @ref wgpuRenderPassEncoderInsertDebugMarker:
  * > @copydoc wgpuRenderPassEncoderInsertDebugMarker
  */
-typedef void (*WGPUProcRenderPassEncoderInsertDebugMarker)(WGPURenderPassEncoder renderPassEncoder, char const * markerLabel) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcRenderPassEncoderInsertDebugMarker)(WGPURenderPassEncoder renderPassEncoder, WGPUStringView markerLabel) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderPassEncoderPopDebugGroup:
  * > @copydoc wgpuRenderPassEncoderPopDebugGroup
@@ -2571,7 +2660,7 @@ typedef void (*WGPUProcRenderPassEncoderPopDebugGroup)(WGPURenderPassEncoder ren
  * Proc pointer type for @ref wgpuRenderPassEncoderPushDebugGroup:
  * > @copydoc wgpuRenderPassEncoderPushDebugGroup
  */
-typedef void (*WGPUProcRenderPassEncoderPushDebugGroup)(WGPURenderPassEncoder renderPassEncoder, char const * groupLabel) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcRenderPassEncoderPushDebugGroup)(WGPURenderPassEncoder renderPassEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderPassEncoderSetBindGroup:
  * > @copydoc wgpuRenderPassEncoderSetBindGroup
@@ -2591,7 +2680,7 @@ typedef void (*WGPUProcRenderPassEncoderSetIndexBuffer)(WGPURenderPassEncoder re
  * Proc pointer type for @ref wgpuRenderPassEncoderSetLabel:
  * > @copydoc wgpuRenderPassEncoderSetLabel
  */
-typedef void (*WGPUProcRenderPassEncoderSetLabel)(WGPURenderPassEncoder renderPassEncoder, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcRenderPassEncoderSetLabel)(WGPURenderPassEncoder renderPassEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderPassEncoderSetPipeline:
  * > @copydoc wgpuRenderPassEncoderSetPipeline
@@ -2638,7 +2727,7 @@ typedef WGPUBindGroupLayout (*WGPUProcRenderPipelineGetBindGroupLayout)(WGPURend
  * Proc pointer type for @ref wgpuRenderPipelineSetLabel:
  * > @copydoc wgpuRenderPipelineSetLabel
  */
-typedef void (*WGPUProcRenderPipelineSetLabel)(WGPURenderPipeline renderPipeline, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcRenderPipelineSetLabel)(WGPURenderPipeline renderPipeline, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderPipelineAddRef.
  * > @copydoc wgpuRenderPipelineAddRef
@@ -2655,7 +2744,7 @@ typedef void (*WGPUProcRenderPipelineRelease)(WGPURenderPipeline renderPipeline)
  * Proc pointer type for @ref wgpuSamplerSetLabel:
  * > @copydoc wgpuSamplerSetLabel
  */
-typedef void (*WGPUProcSamplerSetLabel)(WGPUSampler sampler, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcSamplerSetLabel)(WGPUSampler sampler, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuSamplerAddRef.
  * > @copydoc wgpuSamplerAddRef
@@ -2677,7 +2766,7 @@ typedef WGPUFuture (*WGPUProcShaderModuleGetCompilationInfo)(WGPUShaderModule sh
  * Proc pointer type for @ref wgpuShaderModuleSetLabel:
  * > @copydoc wgpuShaderModuleSetLabel
  */
-typedef void (*WGPUProcShaderModuleSetLabel)(WGPUShaderModule shaderModule, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcShaderModuleSetLabel)(WGPUShaderModule shaderModule, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuShaderModuleAddRef.
  * > @copydoc wgpuShaderModuleAddRef
@@ -2721,7 +2810,7 @@ typedef void (*WGPUProcSurfacePresent)(WGPUSurface surface) WGPU_FUNCTION_ATTRIB
  * Proc pointer type for @ref wgpuSurfaceSetLabel:
  * > @copydoc wgpuSurfaceSetLabel
  */
-typedef void (*WGPUProcSurfaceSetLabel)(WGPUSurface surface, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcSurfaceSetLabel)(WGPUSurface surface, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuSurfaceUnconfigure:
  * > @copydoc wgpuSurfaceUnconfigure
@@ -2800,7 +2889,7 @@ typedef uint32_t (*WGPUProcTextureGetWidth)(WGPUTexture texture) WGPU_FUNCTION_A
  * Proc pointer type for @ref wgpuTextureSetLabel:
  * > @copydoc wgpuTextureSetLabel
  */
-typedef void (*WGPUProcTextureSetLabel)(WGPUTexture texture, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcTextureSetLabel)(WGPUTexture texture, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuTextureAddRef.
  * > @copydoc wgpuTextureAddRef
@@ -2817,7 +2906,7 @@ typedef void (*WGPUProcTextureRelease)(WGPUTexture texture) WGPU_FUNCTION_ATTRIB
  * Proc pointer type for @ref wgpuTextureViewSetLabel:
  * > @copydoc wgpuTextureViewSetLabel
  */
-typedef void (*WGPUProcTextureViewSetLabel)(WGPUTextureView textureView, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcTextureViewSetLabel)(WGPUTextureView textureView, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuTextureViewAddRef.
  * > @copydoc wgpuTextureViewAddRef
@@ -2850,7 +2939,7 @@ WGPU_EXPORT void wgpuGetInstanceFeatures(WGPUInstanceFeatures * features) WGPU_F
  * Returns the "procedure address" (function pointer) of the named function.
  * The result must be cast to the appropriate proc pointer type.
  */
-WGPU_EXPORT WGPUProc wgpuGetProcAddress(char const * procName) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT WGPUProc wgpuGetProcAddress(WGPUStringView procName) WGPU_FUNCTION_ATTRIBUTE;
 
 
 /** @} */
@@ -2906,7 +2995,7 @@ WGPU_EXPORT void wgpuAdapterInfoFreeMembers(WGPUAdapterInfo adapterInfo) WGPU_FU
  *
  * @{
  */
-WGPU_EXPORT void wgpuBindGroupSetLabel(WGPUBindGroup bindGroup, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuBindGroupSetLabel(WGPUBindGroup bindGroup, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBindGroupAddRef(WGPUBindGroup bindGroup) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBindGroupRelease(WGPUBindGroup bindGroup) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -2919,7 +3008,7 @@ WGPU_EXPORT void wgpuBindGroupRelease(WGPUBindGroup bindGroup) WGPU_FUNCTION_ATT
  *
  * @{
  */
-WGPU_EXPORT void wgpuBindGroupLayoutSetLabel(WGPUBindGroupLayout bindGroupLayout, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuBindGroupLayoutSetLabel(WGPUBindGroupLayout bindGroupLayout, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBindGroupLayoutAddRef(WGPUBindGroupLayout bindGroupLayout) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBindGroupLayoutRelease(WGPUBindGroupLayout bindGroupLayout) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -2939,7 +3028,7 @@ WGPU_EXPORT void * wgpuBufferGetMappedRange(WGPUBuffer buffer, size_t offset, si
 WGPU_EXPORT uint64_t wgpuBufferGetSize(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBufferUsage wgpuBufferGetUsage(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUFuture wgpuBufferMapAsync(WGPUBuffer buffer, WGPUMapMode mode, size_t offset, size_t size, WGPUBufferMapCallbackInfo callbackInfo) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuBufferSetLabel(WGPUBuffer buffer, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuBufferSetLabel(WGPUBuffer buffer, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBufferUnmap(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBufferAddRef(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBufferRelease(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
@@ -2953,7 +3042,7 @@ WGPU_EXPORT void wgpuBufferRelease(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
  *
  * @{
  */
-WGPU_EXPORT void wgpuCommandBufferSetLabel(WGPUCommandBuffer commandBuffer, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuCommandBufferSetLabel(WGPUCommandBuffer commandBuffer, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandBufferAddRef(WGPUCommandBuffer commandBuffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandBufferRelease(WGPUCommandBuffer commandBuffer) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -2974,11 +3063,11 @@ WGPU_EXPORT void wgpuCommandEncoderCopyBufferToTexture(WGPUCommandEncoder comman
 WGPU_EXPORT void wgpuCommandEncoderCopyTextureToBuffer(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyBuffer const * destination, WGPUExtent3D const * copySize) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderCopyTextureToTexture(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUCommandBuffer wgpuCommandEncoderFinish(WGPUCommandEncoder commandEncoder, WGPU_NULLABLE WGPUCommandBufferDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuCommandEncoderInsertDebugMarker(WGPUCommandEncoder commandEncoder, char const * markerLabel) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuCommandEncoderInsertDebugMarker(WGPUCommandEncoder commandEncoder, WGPUStringView markerLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderPopDebugGroup(WGPUCommandEncoder commandEncoder) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuCommandEncoderPushDebugGroup(WGPUCommandEncoder commandEncoder, char const * groupLabel) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuCommandEncoderPushDebugGroup(WGPUCommandEncoder commandEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderResolveQuerySet(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t firstQuery, uint32_t queryCount, WGPUBuffer destination, uint64_t destinationOffset) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuCommandEncoderSetLabel(WGPUCommandEncoder commandEncoder, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuCommandEncoderSetLabel(WGPUCommandEncoder commandEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderWriteTimestamp(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t queryIndex) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderAddRef(WGPUCommandEncoder commandEncoder) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderRelease(WGPUCommandEncoder commandEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -2995,11 +3084,11 @@ WGPU_EXPORT void wgpuCommandEncoderRelease(WGPUCommandEncoder commandEncoder) WG
 WGPU_EXPORT void wgpuComputePassEncoderDispatchWorkgroups(WGPUComputePassEncoder computePassEncoder, uint32_t workgroupCountX, uint32_t workgroupCountY, uint32_t workgroupCountZ) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderDispatchWorkgroupsIndirect(WGPUComputePassEncoder computePassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderEnd(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuComputePassEncoderInsertDebugMarker(WGPUComputePassEncoder computePassEncoder, char const * markerLabel) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuComputePassEncoderInsertDebugMarker(WGPUComputePassEncoder computePassEncoder, WGPUStringView markerLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderPopDebugGroup(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuComputePassEncoderPushDebugGroup(WGPUComputePassEncoder computePassEncoder, char const * groupLabel) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuComputePassEncoderPushDebugGroup(WGPUComputePassEncoder computePassEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderSetBindGroup(WGPUComputePassEncoder computePassEncoder, uint32_t groupIndex, WGPU_NULLABLE WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuComputePassEncoderSetLabel(WGPUComputePassEncoder computePassEncoder, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuComputePassEncoderSetLabel(WGPUComputePassEncoder computePassEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderSetPipeline(WGPUComputePassEncoder computePassEncoder, WGPUComputePipeline pipeline) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderAddRef(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderRelease(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -3014,7 +3103,7 @@ WGPU_EXPORT void wgpuComputePassEncoderRelease(WGPUComputePassEncoder computePas
  * @{
  */
 WGPU_EXPORT WGPUBindGroupLayout wgpuComputePipelineGetBindGroupLayout(WGPUComputePipeline computePipeline, uint32_t groupIndex) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuComputePipelineSetLabel(WGPUComputePipeline computePipeline, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuComputePipelineSetLabel(WGPUComputePipeline computePipeline, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePipelineAddRef(WGPUComputePipeline computePipeline) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePipelineRelease(WGPUComputePipeline computePipeline) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -3055,7 +3144,7 @@ WGPU_EXPORT WGPUQueue wgpuDeviceGetQueue(WGPUDevice device) WGPU_FUNCTION_ATTRIB
 WGPU_EXPORT WGPUBool wgpuDeviceHasFeature(WGPUDevice device, WGPUFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUFuture wgpuDevicePopErrorScope(WGPUDevice device, WGPUPopErrorScopeCallbackInfo callbackInfo) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuDevicePushErrorScope(WGPUDevice device, WGPUErrorFilter filter) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuDeviceSetLabel(WGPUDevice device, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuDeviceSetLabel(WGPUDevice device, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuDeviceAddRef(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuDeviceRelease(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -3100,7 +3189,7 @@ WGPU_EXPORT void wgpuInstanceRelease(WGPUInstance instance) WGPU_FUNCTION_ATTRIB
  *
  * @{
  */
-WGPU_EXPORT void wgpuPipelineLayoutSetLabel(WGPUPipelineLayout pipelineLayout, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuPipelineLayoutSetLabel(WGPUPipelineLayout pipelineLayout, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuPipelineLayoutAddRef(WGPUPipelineLayout pipelineLayout) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuPipelineLayoutRelease(WGPUPipelineLayout pipelineLayout) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -3116,7 +3205,7 @@ WGPU_EXPORT void wgpuPipelineLayoutRelease(WGPUPipelineLayout pipelineLayout) WG
 WGPU_EXPORT void wgpuQuerySetDestroy(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT uint32_t wgpuQuerySetGetCount(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUQueryType wgpuQuerySetGetType(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuQuerySetSetLabel(WGPUQuerySet querySet, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuQuerySetSetLabel(WGPUQuerySet querySet, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQuerySetAddRef(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQuerySetRelease(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -3130,7 +3219,7 @@ WGPU_EXPORT void wgpuQuerySetRelease(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIB
  * @{
  */
 WGPU_EXPORT WGPUFuture wgpuQueueOnSubmittedWorkDone(WGPUQueue queue, WGPUQueueWorkDoneCallbackInfo callbackInfo) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuQueueSetLabel(WGPUQueue queue, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuQueueSetLabel(WGPUQueue queue, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueWriteBuffer(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, void const * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueWriteTexture(WGPUQueue queue, WGPUImageCopyTexture const * destination, void const * data, size_t dataSize, WGPUTextureDataLayout const * dataLayout, WGPUExtent3D const * writeSize) WGPU_FUNCTION_ATTRIBUTE;
@@ -3146,7 +3235,7 @@ WGPU_EXPORT void wgpuQueueRelease(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
  *
  * @{
  */
-WGPU_EXPORT void wgpuRenderBundleSetLabel(WGPURenderBundle renderBundle, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderBundleSetLabel(WGPURenderBundle renderBundle, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleAddRef(WGPURenderBundle renderBundle) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleRelease(WGPURenderBundle renderBundle) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -3164,12 +3253,12 @@ WGPU_EXPORT void wgpuRenderBundleEncoderDrawIndexed(WGPURenderBundleEncoder rend
 WGPU_EXPORT void wgpuRenderBundleEncoderDrawIndexedIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderDrawIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPURenderBundle wgpuRenderBundleEncoderFinish(WGPURenderBundleEncoder renderBundleEncoder, WGPU_NULLABLE WGPURenderBundleDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuRenderBundleEncoderInsertDebugMarker(WGPURenderBundleEncoder renderBundleEncoder, char const * markerLabel) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderBundleEncoderInsertDebugMarker(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView markerLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderPopDebugGroup(WGPURenderBundleEncoder renderBundleEncoder) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuRenderBundleEncoderPushDebugGroup(WGPURenderBundleEncoder renderBundleEncoder, char const * groupLabel) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderBundleEncoderPushDebugGroup(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetBindGroup(WGPURenderBundleEncoder renderBundleEncoder, uint32_t groupIndex, WGPU_NULLABLE WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetIndexBuffer(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuRenderBundleEncoderSetLabel(WGPURenderBundleEncoder renderBundleEncoder, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderBundleEncoderSetLabel(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetPipeline(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderPipeline pipeline) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetVertexBuffer(WGPURenderBundleEncoder renderBundleEncoder, uint32_t slot, WGPU_NULLABLE WGPUBuffer buffer, uint64_t offset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderAddRef(WGPURenderBundleEncoder renderBundleEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -3192,13 +3281,13 @@ WGPU_EXPORT void wgpuRenderPassEncoderDrawIndirect(WGPURenderPassEncoder renderP
 WGPU_EXPORT void wgpuRenderPassEncoderEnd(WGPURenderPassEncoder renderPassEncoder) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderEndOcclusionQuery(WGPURenderPassEncoder renderPassEncoder) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderExecuteBundles(WGPURenderPassEncoder renderPassEncoder, size_t bundleCount, WGPURenderBundle const * bundles) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuRenderPassEncoderInsertDebugMarker(WGPURenderPassEncoder renderPassEncoder, char const * markerLabel) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderPassEncoderInsertDebugMarker(WGPURenderPassEncoder renderPassEncoder, WGPUStringView markerLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderPopDebugGroup(WGPURenderPassEncoder renderPassEncoder) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuRenderPassEncoderPushDebugGroup(WGPURenderPassEncoder renderPassEncoder, char const * groupLabel) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderPassEncoderPushDebugGroup(WGPURenderPassEncoder renderPassEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder renderPassEncoder, uint32_t groupIndex, WGPU_NULLABLE WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetBlendConstant(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetIndexBuffer(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuRenderPassEncoderSetLabel(WGPURenderPassEncoder renderPassEncoder, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderPassEncoderSetLabel(WGPURenderPassEncoder renderPassEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetPipeline(WGPURenderPassEncoder renderPassEncoder, WGPURenderPipeline pipeline) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetScissorRect(WGPURenderPassEncoder renderPassEncoder, uint32_t x, uint32_t y, uint32_t width, uint32_t height) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetStencilReference(WGPURenderPassEncoder renderPassEncoder, uint32_t reference) WGPU_FUNCTION_ATTRIBUTE;
@@ -3217,7 +3306,7 @@ WGPU_EXPORT void wgpuRenderPassEncoderRelease(WGPURenderPassEncoder renderPassEn
  * @{
  */
 WGPU_EXPORT WGPUBindGroupLayout wgpuRenderPipelineGetBindGroupLayout(WGPURenderPipeline renderPipeline, uint32_t groupIndex) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuRenderPipelineSetLabel(WGPURenderPipeline renderPipeline, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderPipelineSetLabel(WGPURenderPipeline renderPipeline, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPipelineAddRef(WGPURenderPipeline renderPipeline) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPipelineRelease(WGPURenderPipeline renderPipeline) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -3230,7 +3319,7 @@ WGPU_EXPORT void wgpuRenderPipelineRelease(WGPURenderPipeline renderPipeline) WG
  *
  * @{
  */
-WGPU_EXPORT void wgpuSamplerSetLabel(WGPUSampler sampler, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuSamplerSetLabel(WGPUSampler sampler, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuSamplerAddRef(WGPUSampler sampler) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuSamplerRelease(WGPUSampler sampler) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -3244,7 +3333,7 @@ WGPU_EXPORT void wgpuSamplerRelease(WGPUSampler sampler) WGPU_FUNCTION_ATTRIBUTE
  * @{
  */
 WGPU_EXPORT WGPUFuture wgpuShaderModuleGetCompilationInfo(WGPUShaderModule shaderModule, WGPUCompilationInfoCallbackInfo callbackInfo) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuShaderModuleSetLabel(WGPUShaderModule shaderModule, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuShaderModuleSetLabel(WGPUShaderModule shaderModule, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuShaderModuleAddRef(WGPUShaderModule shaderModule) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuShaderModuleRelease(WGPUShaderModule shaderModule) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -3296,7 +3385,7 @@ WGPU_EXPORT void wgpuSurfacePresent(WGPUSurface surface) WGPU_FUNCTION_ATTRIBUTE
 /**
  * Modifies the label used to refer to `surface`.
  */
-WGPU_EXPORT void wgpuSurfaceSetLabel(WGPUSurface surface, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuSurfaceSetLabel(WGPUSurface surface, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Removes the configuration for `surface`.
  * See @ref Surface-Configuration for more details.
@@ -3338,7 +3427,7 @@ WGPU_EXPORT uint32_t wgpuTextureGetMipLevelCount(WGPUTexture texture) WGPU_FUNCT
 WGPU_EXPORT uint32_t wgpuTextureGetSampleCount(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUTextureUsage wgpuTextureGetUsage(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT uint32_t wgpuTextureGetWidth(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuTextureSetLabel(WGPUTexture texture, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuTextureSetLabel(WGPUTexture texture, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuTextureAddRef(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuTextureRelease(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
@@ -3351,7 +3440,7 @@ WGPU_EXPORT void wgpuTextureRelease(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE
  *
  * @{
  */
-WGPU_EXPORT void wgpuTextureViewSetLabel(WGPUTextureView textureView, char const * label) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuTextureViewSetLabel(WGPUTextureView textureView, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuTextureViewAddRef(WGPUTextureView textureView) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuTextureViewRelease(WGPUTextureView textureView) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1456,19 +1456,19 @@ structs:
       - name: vendor
         doc: |
           TODO
-        type: string
+        type: out_string
       - name: architecture
         doc: |
           TODO
-        type: string
+        type: out_string
       - name: device
         doc: |
           TODO
-        type: string
+        type: out_string
       - name: description
         doc: |
           TODO
-        type: string
+        type: out_string
       - name: backend_type
         doc: |
           TODO
@@ -1493,8 +1493,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: layout
         doc: |
           TODO
@@ -1544,8 +1543,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: entries
         doc: |
           TODO
@@ -1635,8 +1633,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: usage
         doc: |
           TODO
@@ -1697,8 +1694,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
   - name: command_encoder_descriptor
     doc: |
       TODO
@@ -1707,8 +1703,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
   - name: compilation_info
     doc: |
       TODO
@@ -1727,8 +1722,7 @@ structs:
       - name: message
         doc: |
           TODO
-        type: string
-        optional: true
+        type: out_string
       - name: type
         doc: |
           TODO
@@ -1769,8 +1763,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: timestamp_writes
         doc: |
           TODO
@@ -1802,8 +1795,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: layout
         doc: |
           TODO
@@ -1821,7 +1813,7 @@ structs:
       - name: key
         doc: |
           TODO
-        type: string
+        type: string_with_default_empty
       - name: value
         doc: |
           TODO
@@ -1879,8 +1871,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: required_features
         doc: |
           TODO
@@ -1933,8 +1924,7 @@ structs:
       - name: entry_point
         doc: |
           TODO
-        type: string
-        optional: true
+        type: nullable_string
       - name: constants
         doc: |
           TODO
@@ -2186,8 +2176,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: bind_group_layouts
         doc: |
           TODO
@@ -2230,8 +2219,7 @@ structs:
       - name: entry_point
         doc: |
           TODO
-        type: string
-        optional: true
+        type: nullable_string
       - name: constants
         doc: |
           TODO
@@ -2245,8 +2233,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: type
         doc: |
           TODO
@@ -2263,8 +2250,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
   - name: render_bundle_descriptor
     doc: |
       TODO
@@ -2273,8 +2259,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
   - name: render_bundle_encoder_descriptor
     doc: |
       TODO
@@ -2283,8 +2268,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: color_formats
         doc: |
           TODO
@@ -2386,8 +2370,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: color_attachments
         doc: |
           TODO
@@ -2446,8 +2429,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: layout
         doc: |
           TODO
@@ -2525,8 +2507,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: address_mode_u
         doc: |
           TODO
@@ -2575,8 +2556,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
   - name: shader_source_SPIRV
     doc: |
       TODO
@@ -2603,7 +2583,7 @@ structs:
       - name: code
         doc: |
           TODO
-        type: string
+        type: string_with_default_empty
   - name: stencil_face_state
     doc: |
       TODO
@@ -2728,8 +2708,7 @@ structs:
     members:
       - name: label
         doc: Label used to refer to the object.
-        type: string
-        optional: true
+        type: string_with_default_empty
   - name: surface_source_android_native_window
     doc: Chained in @ref WGPUSurfaceDescriptor to make an @ref WGPUSurface wrapping an Android [`ANativeWindow`](https://developer.android.com/ndk/reference/group/a-native-window).
     type: extension_in
@@ -2860,8 +2839,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: usage
         doc: |
           TODO
@@ -2899,8 +2877,7 @@ structs:
       - name: label
         doc: |
           TODO
-        type: string
-        optional: true
+        type: string_with_default_empty
       - name: format
         doc: |
           TODO
@@ -2980,8 +2957,7 @@ structs:
       - name: entry_point
         doc: |
           TODO
-        type: string
-        optional: true
+        type: nullable_string
       - name: constants
         doc: |
           TODO
@@ -3005,7 +2981,7 @@ callbacks:
       - name: message
         doc: |
           TODO
-        type: string
+        type: out_string
   - name: compilation_info
     doc: |
       TODO
@@ -3036,7 +3012,7 @@ callbacks:
       - name: message
         doc: |
           TODO
-        type: string
+        type: out_string
   - name: create_render_pipeline_async
     doc: |
       TODO
@@ -3053,7 +3029,7 @@ callbacks:
       - name: message
         doc: |
           TODO
-        type: string
+        type: out_string
   - name: device_lost
     doc: TODO
     style: callback_mode
@@ -3070,7 +3046,7 @@ callbacks:
       - name: message
         doc: |
           TODO
-        type: string
+        type: out_string
   - name: pop_error_scope
     doc: |
       TODO
@@ -3087,7 +3063,7 @@ callbacks:
       - name: message
         doc: |
           TODO
-        type: string
+        type: out_string
   - name: queue_work_done
     doc: |
       TODO
@@ -3113,7 +3089,7 @@ callbacks:
       - name: message
         doc: |
           TODO
-        type: string
+        type: out_string
   - name: request_device
     doc: |
       TODO
@@ -3130,7 +3106,7 @@ callbacks:
       - name: message
         doc: |
           TODO
-        type: string
+        type: out_string
   - name: uncaptured_error
     doc: |
       TODO
@@ -3148,7 +3124,7 @@ callbacks:
       - name: message
         doc: |
           TODO
-        type: string
+        type: out_string
 functions:
   - name: create_instance
     doc: Create a WGPUInstance
@@ -3246,7 +3222,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: bind_group_layout
     doc: |
       TODO
@@ -3258,7 +3234,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: buffer
     doc: |
       TODO
@@ -3321,7 +3297,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: get_usage
         doc: |
           TODO
@@ -3360,7 +3336,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: command_encoder
     doc: |
       TODO
@@ -3510,7 +3486,7 @@ objects:
           - name: marker_label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: pop_debug_group
         doc: |
           TODO
@@ -3521,7 +3497,7 @@ objects:
           - name: group_label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: resolve_query_set
         doc: |
           TODO
@@ -3565,7 +3541,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: compute_pass_encoder
     doc: |
       TODO
@@ -3577,7 +3553,7 @@ objects:
           - name: marker_label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: pop_debug_group
         doc: |
           TODO
@@ -3588,7 +3564,7 @@ objects:
           - name: group_label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: set_pipeline
         doc: |
           TODO
@@ -3653,7 +3629,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: compute_pipeline
     doc: |
       TODO
@@ -3677,7 +3653,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: device
     doc: |
       TODO
@@ -3929,7 +3905,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: instance
     doc: |
       TODO
@@ -4007,7 +3983,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: query_set
     doc: |
       TODO
@@ -4019,7 +3995,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: get_type
         doc: |
           TODO
@@ -4110,7 +4086,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: render_bundle
     doc: |
       TODO
@@ -4122,7 +4098,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: render_bundle_encoder
     doc: |
       TODO
@@ -4228,7 +4204,7 @@ objects:
           - name: marker_label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: pop_debug_group
         doc: |
           TODO
@@ -4239,7 +4215,7 @@ objects:
           - name: group_label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: set_vertex_buffer
         doc: |
           TODO
@@ -4302,7 +4278,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: render_pass_encoder
     doc: |
       TODO
@@ -4417,7 +4393,7 @@ objects:
           - name: marker_label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: pop_debug_group
         doc: |
           TODO
@@ -4428,7 +4404,7 @@ objects:
           - name: group_label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: set_stencil_reference
         doc: |
           TODO
@@ -4556,7 +4532,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: render_pipeline
     doc: |
       TODO
@@ -4580,7 +4556,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: sampler
     doc: |
       TODO
@@ -4592,7 +4568,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: shader_module
     doc: |
       TODO
@@ -4608,7 +4584,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
   - name: surface
     doc: An object used to continuously present image data to the user, see @ref Surfaces for more details.
     methods:
@@ -4660,7 +4636,7 @@ objects:
         args:
           - name: label
             doc: The new label.
-            type: string
+            type: string_with_default_empty
   - name: texture
     doc: |
       TODO
@@ -4686,7 +4662,7 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty
       - name: get_width
         doc: |
           TODO
@@ -4757,4 +4733,4 @@ objects:
           - name: label
             doc: |
               TODO
-            type: string
+            type: string_with_default_empty


### PR DESCRIPTION
I split `string` into three types in the schema:
- `string_with_default_empty` for cases where `{nullptr,STRLEN}` = `""`
- `nullable_string` for cases where `{nullptr,STRLEN}` = `nil`
- `out_string` for outputs (always explicitly sized)

But in C they are all just `WGPUStringView`. The difference is explained in a newly-generated doc comment.

Fixes #170
Fixes #351