### PR TITLE
Add GPUSurfaceConfiguration.colorSpace

### DIFF
--- a/doc/articles/Surfaces.md
+++ b/doc/articles/Surfaces.md
@@ -90,7 +90,7 @@ if (!wgpuSurfaceGetCapabilities(mySurface, myAdapter, &caps)) {
 
 // Do things with capabilities
 bool canSampleSurface = caps.usages & WGPUTextureUsage_TextureBinding;
-WGPUTextureFormat preferredFormat = caps.format[0];
+WGPUTextureFormat preferredFormat = caps.formats[0];
 
 bool supportsMailbox = false;
 for (size_t i = 0; i < caps.presentModeCount; i++) {

--- a/webgpu.h
+++ b/webgpu.h
@@ -366,6 +366,23 @@ typedef enum WGPUCallbackMode {
     WGPUCallbackMode_Force32 = 0x7FFFFFFF
 } WGPUCallbackMode WGPU_ENUM_ATTRIBUTE;
 
+/**
+ * Predefined sets of color space parameters.
+ */
+typedef enum WGPUColorSpace {
+    /**
+     * `0x00000000`.
+     * The color space defined by [`srgb`](https://www.w3.org/TR/css-color-4/#predefined-sRGB) in CSS.
+     */
+    WGPUColorSpace_SRGB = 0x00000000,
+    /**
+     * `0x00000001`.
+     * The color space defined by [`display-p3`](https://www.w3.org/TR/css-color-4/#predefined-display-p3) in CSS.
+     */
+    WGPUColorSpace_DisplayP3 = 0x00000001,
+    WGPUColorSpace_Force32 = 0x7FFFFFFF
+} WGPUColorSpace WGPU_ENUM_ATTRIBUTE;
+
 typedef enum WGPUCompareFunction {
     WGPUCompareFunction_Undefined = 0x00000000,
     WGPUCompareFunction_Never = 0x00000001,
@@ -1539,6 +1556,14 @@ typedef struct WGPUSurfaceConfiguration {
      * When and in which order the surface's frames will be shown on the screen. Defaults to @ref WGPUPresentMode_Fifo.
      */
     WGPUPresentMode presentMode;
+    /**
+     * Color space to display the surface with.
+     *
+     * The only value that implementations are required to support is @ref WGPUColorSpace_Undefined,
+     * which may be either "unmanaged" or "sRGB".
+     * Wasm implementations should support @ref WGPUColorSpace_sRGB and @ref WGPUColorSpace_DisplayP3.
+     */
+    WGPUColorSpace colorSpace;
 } WGPUSurfaceConfiguration WGPU_STRUCTURE_ATTRIBUTE;
 
 /**

--- a/webgpu.h
+++ b/webgpu.h
@@ -1561,7 +1561,7 @@ typedef struct WGPUSurfaceConfiguration {
      *
      * The only value that implementations are required to support is @ref WGPUColorSpace_Undefined,
      * which may be either "unmanaged" or "sRGB".
-     * Wasm implementations should support @ref WGPUColorSpace_sRGB and @ref WGPUColorSpace_DisplayP3.
+     * Wasm implementations should support @ref WGPUColorSpace_SRGB and @ref WGPUColorSpace_DisplayP3.
      */
     WGPUColorSpace colorSpace;
 } WGPUSurfaceConfiguration WGPU_STRUCTURE_ATTRIBUTE;

--- a/webgpu.h
+++ b/webgpu.h
@@ -402,7 +402,7 @@ typedef enum WGPUCallbackMode {
 typedef enum WGPUColorSpace {
     /**
      * `0x00000000`.
-     * Use the default color space.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUColorSpace_Undefined = 0x00000000,
     /**
@@ -1703,7 +1703,7 @@ typedef struct WGPUSurfaceConfiguration {
      * Color space to display the surface with.
      *
      * The only value that implementations are required to support is @ref WGPUColorSpace_Undefined,
-     * which may be either "unmanaged" or "sRGB".
+     * which may be either "unmanaged" or "sRGB" in native (translates to the default `"srgb"` in Wasm).
      * Wasm implementations should support @ref WGPUColorSpace_SRGB and @ref WGPUColorSpace_DisplayP3.
      */
     WGPUColorSpace colorSpace;

--- a/webgpu.h
+++ b/webgpu.h
@@ -372,14 +372,19 @@ typedef enum WGPUCallbackMode {
 typedef enum WGPUColorSpace {
     /**
      * `0x00000000`.
-     * The color space defined by [`srgb`](https://www.w3.org/TR/css-color-4/#predefined-sRGB) in CSS.
+     * Use the default color space.
      */
-    WGPUColorSpace_SRGB = 0x00000000,
+    WGPUColorSpace_Undefined = 0x00000000,
     /**
      * `0x00000001`.
+     * The color space defined by [`srgb`](https://www.w3.org/TR/css-color-4/#predefined-sRGB) in CSS.
+     */
+    WGPUColorSpace_SRGB = 0x00000001,
+    /**
+     * `0x00000002`.
      * The color space defined by [`display-p3`](https://www.w3.org/TR/css-color-4/#predefined-display-p3) in CSS.
      */
-    WGPUColorSpace_DisplayP3 = 0x00000001,
+    WGPUColorSpace_DisplayP3 = 0x00000002,
     WGPUColorSpace_Force32 = 0x7FFFFFFF
 } WGPUColorSpace WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -2712,7 +2712,7 @@ structs:
 
           The only value that implementations are required to support is @ref WGPUColorSpace_Undefined,
           which may be either "unmanaged" or "sRGB".
-          Wasm implementations should support @ref WGPUColorSpace_sRGB and @ref WGPUColorSpace_DisplayP3.
+          Wasm implementations should support @ref WGPUColorSpace_SRGB and @ref WGPUColorSpace_DisplayP3.
         type: enum.color_space
   - name: surface_descriptor
     doc: |

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -43,6 +43,13 @@ constants:
       TODO
 typedefs: []
 enums:
+  - name: color_space
+    doc: Predefined sets of color space parameters.
+    entries:
+      - name: sRGB
+        doc: The color space defined by [`srgb`](https://www.w3.org/TR/css-color-4/#predefined-sRGB) in CSS.
+      - name: display_p3
+        doc: The color space defined by [`display-p3`](https://www.w3.org/TR/css-color-4/#predefined-display-p3) in CSS.
   - name: adapter_type
     doc: |
       TODO
@@ -2699,6 +2706,14 @@ structs:
       - name: present_mode
         doc: When and in which order the surface's frames will be shown on the screen. Defaults to @ref WGPUPresentMode_Fifo.
         type: enum.present_mode
+      - name: color_space
+        doc: |
+          Color space to display the surface with.
+
+          The only value that implementations are required to support is @ref WGPUColorSpace_Undefined,
+          which may be either "unmanaged" or "sRGB".
+          Wasm implementations should support @ref WGPUColorSpace_sRGB and @ref WGPUColorSpace_DisplayP3.
+        type: enum.color_space
   - name: surface_descriptor
     doc: |
       The root descriptor for the creation of an @ref WGPUSurface with `::wgpuInstanceCreateSurface`.

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -43,13 +43,6 @@ constants:
       TODO
 typedefs: []
 enums:
-  - name: color_space
-    doc: Predefined sets of color space parameters.
-    entries:
-      - name: sRGB
-        doc: The color space defined by [`srgb`](https://www.w3.org/TR/css-color-4/#predefined-sRGB) in CSS.
-      - name: display_p3
-        doc: The color space defined by [`display-p3`](https://www.w3.org/TR/css-color-4/#predefined-display-p3) in CSS.
   - name: adapter_type
     doc: |
       TODO
@@ -226,6 +219,13 @@ enums:
             Implementations _should_ fire spontaneous callbacks as soon as possible.
 
           @note Because spontaneous callbacks may fire at an arbitrary time on an arbitrary thread, applications should take extra care when acquiring locks or mutating state inside the callback. It undefined behavior to re-entrantly call into the webgpu.h API if the callback fires while inside the callstack of another webgpu.h function that is not `wgpuInstanceWaitAny` or `wgpuInstanceProcessEvents`.
+  - name: color_space
+    doc: Predefined sets of color space parameters.
+    entries:
+      - name: sRGB
+        doc: The color space defined by [`srgb`](https://www.w3.org/TR/css-color-4/#predefined-sRGB) in CSS.
+      - name: display_p3
+        doc: The color space defined by [`display-p3`](https://www.w3.org/TR/css-color-4/#predefined-display-p3) in CSS.
   - name: compare_function
     doc: |
       TODO

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -232,7 +232,7 @@ enums:
     doc: Predefined sets of color space parameters.
     entries:
       - name: undefined
-        doc: Use the default color space.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: sRGB
         doc: The color space defined by [`srgb`](https://www.w3.org/TR/css-color-4/#predefined-sRGB) in CSS.
       - name: display_p3
@@ -2720,7 +2720,7 @@ structs:
           Color space to display the surface with.
 
           The only value that implementations are required to support is @ref WGPUColorSpace_Undefined,
-          which may be either "unmanaged" or "sRGB".
+          which may be either "unmanaged" or "sRGB" in native (translates to the default `"srgb"` in Wasm).
           Wasm implementations should support @ref WGPUColorSpace_SRGB and @ref WGPUColorSpace_DisplayP3.
         type: enum.color_space
   - name: surface_descriptor

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -222,6 +222,8 @@ enums:
   - name: color_space
     doc: Predefined sets of color space parameters.
     entries:
+      - name: undefined
+        doc: Use the default color space.
       - name: sRGB
         doc: The color space defined by [`srgb`](https://www.w3.org/TR/css-color-4/#predefined-sRGB) in CSS.
       - name: display_p3


### PR DESCRIPTION
bikeshedding:
- naming of WGPUColorSpace (WGPUPredefinedColorSpace? note we are likely to use it in non-surface places for copyExternalImageToTexture/importExternalTexture)
- capitalization of WGPUColorSpace_SRGB (Srgb? sRGB?)

Fixes #200