### PR TITLE
Add surface tone mapping mode

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -730,6 +730,32 @@ typedef enum WGPUSurfaceGetCurrentTextureStatus {
     WGPUSurfaceGetCurrentTextureStatus_Force32 = 0x7FFFFFFF
 } WGPUSurfaceGetCurrentTextureStatus WGPU_ENUM_ATTRIBUTE;
 
+/**
+ * Specifies how color values are displayed to the screen.
+ */
+typedef enum WGPUSurfaceToneMappingMode {
+    /**
+     * `0x00000000`.
+     * Use the default tone mapping mode (@ref WGPUSurfaceToneMappingMode_Standard).
+     */
+    WGPUSurfaceToneMappingMode_Undefined = 0x00000000,
+    /**
+     * `0x00000001`.
+     * Color values within the standard dynamic range of the screen are
+     * unchanged, and all other color values are projected to the standard
+     * dynamic range of the screen.
+     */
+    WGPUSurfaceToneMappingMode_Standard = 0x00000001,
+    /**
+     * `0x00000002`.
+     * Color values in the extended dynamic range of the screen are
+     * unchanged, and all other color values are projected to the extended
+     * dynamic range of the screen.
+     */
+    WGPUSurfaceToneMappingMode_Extended = 0x00000002,
+    WGPUSurfaceToneMappingMode_Force32 = 0x7FFFFFFF
+} WGPUSurfaceToneMappingMode WGPU_ENUM_ATTRIBUTE;
+
 typedef enum WGPUTextureAspect {
     WGPUTextureAspect_All = 0x00000000,
     WGPUTextureAspect_StencilOnly = 0x00000001,
@@ -1539,6 +1565,12 @@ typedef struct WGPUSurfaceConfiguration {
      * When and in which order the surface's frames will be shown on the screen. Defaults to @ref WGPUPresentMode_Fifo.
      */
     WGPUPresentMode presentMode;
+    /**
+     * Specifies how color values are displayed to the screen.
+     *
+     * Implementation support is not required for @ref WGPUSurfaceToneMappping_Extended.
+     */
+    WGPUSurfaceToneMappingMode toneMappingMode;
 } WGPUSurfaceConfiguration WGPU_STRUCTURE_ATTRIBUTE;
 
 /**

--- a/webgpu.h
+++ b/webgpu.h
@@ -837,7 +837,7 @@ typedef enum WGPUSurfaceGetCurrentTextureStatus {
 typedef enum WGPUSurfaceToneMappingMode {
     /**
      * `0x00000000`.
-     * Use the default tone mapping mode (@ref WGPUSurfaceToneMappingMode_Standard).
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUSurfaceToneMappingMode_Undefined = 0x00000000,
     /**
@@ -1705,8 +1705,9 @@ typedef struct WGPUSurfaceConfiguration {
     WGPUPresentMode presentMode;
     /**
      * Specifies how color values are displayed to the screen.
+     * If @ref WGPUSurfaceToneMappingMode_Undefined, defaults to @ref WGPUSurfaceToneMappingMode_Standard.
      *
-     * Implementation support is not required for @ref WGPUSurfaceToneMappping_Extended.
+     * Implementation support is not required for @ref WGPUSurfaceToneMappingMode_Extended.
      */
     WGPUSurfaceToneMappingMode toneMappingMode;
 } WGPUSurfaceConfiguration WGPU_STRUCTURE_ATTRIBUTE;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -823,7 +823,7 @@ enums:
     doc: Specifies how color values are displayed to the screen.
     entries:
       - name: undefined
-        doc: Use the default tone mapping mode (@ref WGPUSurfaceToneMappingMode_Standard).
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: standard
         doc: |
           Color values within the standard dynamic range of the screen are
@@ -2724,8 +2724,9 @@ structs:
       - name: tone_mapping_mode
         doc: |
           Specifies how color values are displayed to the screen.
+          If @ref WGPUSurfaceToneMappingMode_Undefined, defaults to @ref WGPUSurfaceToneMappingMode_Standard.
 
-          Implementation support is not required for @ref WGPUSurfaceToneMappping_Extended.
+          Implementation support is not required for @ref WGPUSurfaceToneMappingMode_Extended.
         type: enum.surface_tone_mapping_mode
   - name: surface_descriptor
     doc: |

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -820,6 +820,21 @@ enums:
         doc: The system ran out of memory.
       - name: device_lost
         doc: The @ref WGPUDevice configured on the @ref WGPUSurface was lost.
+  - name: surface_tone_mapping_mode
+    doc: Specifies how color values are displayed to the screen.
+    entries:
+      - name: undefined
+        doc: Use the default tone mapping mode (@ref WGPUSurfaceToneMappingMode_Standard).
+      - name: standard
+        doc: |
+          Color values within the standard dynamic range of the screen are
+          unchanged, and all other color values are projected to the standard
+          dynamic range of the screen.
+      - name: extended
+        doc: |
+          Color values in the extended dynamic range of the screen are
+          unchanged, and all other color values are projected to the extended
+          dynamic range of the screen.
   - name: texture_aspect
     doc: |
       TODO
@@ -2699,6 +2714,12 @@ structs:
       - name: present_mode
         doc: When and in which order the surface's frames will be shown on the screen. Defaults to @ref WGPUPresentMode_Fifo.
         type: enum.present_mode
+      - name: tone_mapping_mode
+        doc: |
+          Specifies how color values are displayed to the screen.
+
+          Implementation support is not required for @ref WGPUSurfaceToneMappping_Extended.
+        type: enum.surface_tone_mapping_mode
   - name: surface_descriptor
     doc: |
       The root descriptor for the creation of an @ref WGPUSurface with `::wgpuInstanceCreateSurface`.


### PR DESCRIPTION
Proposal.

This is in the JS spec, so like #200, we should probably add it here too, though I don't know if native implementations will need more than this for HDR. We could move this to a Wasm-specific extension.

I don't know anything about what this looks like in native so hopefully others do.