### PR TITLE
Update all sentinel values, reserve 0

### DIFF
--- a/doc/articles/SentinelValues.md
+++ b/doc/articles/SentinelValues.md
@@ -1,0 +1,38 @@
+# Sentinel Values {#SentinelValues}
+
+## Undefined
+
+Since WebGPU is defined first as a JavaScript API, it uses the JavaScript value
+`undefined` in many places to indicate the lack of a value.
+
+This is usually used in dictionaries, where, for example, `{}` and
+`{ powerPreference: undefined }` are equivalent, and distinct from both
+`{ powerPreference: "high-performance" }` and `{ powerPreference: "low-power" }`.
+
+It may also be used in functions/methods. For example, `GPUBuffer`'s
+`getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size)`
+can be called equivalently as `b.getMappedRange()`, `b.getMappedRange(0)`,
+`b.getMappedRange(undefined)`, or `b.getMappedRange(undefined, undefined)`.
+
+To represent `undefined` in C, `webgpu.h` uses `*_UNDEFINED` sentinel numeric values
+(generally `UINT32_MAX`, etc.) and `*_Undefined` enum values (generally `0`).
+
+The place that uses the type will define what to do with an undefined value.
+It may be:
+
+- Required, in which case an error is produced.
+- Defaulting, in which case it trivially defaults to some other value.
+- Optional, in which case the API accepts the sentinel value and handles it
+  (usually this is either a special value or it has more complex defaulting,
+  for example depending on other values).
+
+## Other sentinel values
+
+Undefined values are also be used in C-specific ways in place of WebIDL's
+more flexible typing:
+
+- \ref WGPUVertexStepMode_VertexBufferNotUsed
+- \ref WGPUBufferBindingType_BindingNotUsed
+- \ref WGPUSamplerBindingType_BindingNotUsed
+- \ref WGPUTextureSampleType_BindingNotUsed
+- \ref WGPUStorageTextureAccess_BindingNotUsed

--- a/doc/articles/index.md
+++ b/doc/articles/index.md
@@ -2,3 +2,4 @@
 
 - \subpage Asynchronous-Operations
 - \subpage Surfaces
+- \subpage SentinelValues

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -193,14 +193,18 @@ struct WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}};
 {{- range $enum := .Enums}}
 {{-   if .Extended}}
 {{-     range $entryIndex, $_ := .Entries}}
+{{-       if .}}
 _wgpu_EXTEND_ENUM(WGPU{{$enum.Name | PascalCase}}, WGPU{{$enum.Name | PascalCase}}_{{.Name | PascalCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}}, {{EnumValue $.EnumPrefix $enum $entryIndex}});
+{{-       end}}
 {{-     end}}
 {{-   else}}
 {{-     MComment .Doc 0}}
 typedef enum WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} {
 {{-     range $entryIndex, $_ := .Entries}}
-{{-       MCommentEnum .Doc 4 $.EnumPrefix $enum $entryIndex }}
+{{-       if .}}
+{{-         MCommentEnum .Doc 4 $.EnumPrefix $enum $entryIndex }}
     WGPU{{$enum.Name | PascalCase}}_{{.Name | PascalCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} = {{EnumValue $.EnumPrefix $enum $entryIndex}},
+{{-       end}}
 {{-     end}}
     WGPU{{$enum.Name | PascalCase}}_Force32{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} = 0x7FFFFFFF
 } WGPU{{$enum.Name | PascalCase}}{{$.ExtSuffix}} WGPU_ENUM_ATTRIBUTE;

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -58,7 +58,7 @@ func (g *Generator) Gen(dst io.Writer) error {
 				if srcDoc != "" && srcDoc != "TODO" {
 					s += srcDoc
 				}
-			
+
 				switch typ {
 				case "nullable_string":
 					s += "\n\nThis string is nullable."

--- a/gen/main.go
+++ b/gen/main.go
@@ -120,7 +120,7 @@ func SortAndTransform(yml *Yml) {
 			yml.Objects = append(yml.Objects, Object{
 				IsStruct: true,
 				Name:     s.Name,
-				Methods:  []Function{{
+				Methods: []Function{{
 					Name: "free_members",
 					Doc:  "Frees array members of WGPU" + PascalCase(s.Name) + " which were allocated by the API.",
 				}},

--- a/gen/validator.go
+++ b/gen/validator.go
@@ -70,10 +70,12 @@ func mergeAndValidateDuplicates(yamlPaths []string) (errs error) {
 					errs = errors.Join(errs, fmt.Errorf("merge: enums.%s in %s is being extended but isn't marked as one", e.Name, yamlPath))
 				}
 				for _, entry := range e.Entries {
-					if slices.ContainsFunc(prevEnum.Entries, func(e EnumEntry) bool { return e.Name == entry.Name }) {
-						errs = errors.Join(errs, fmt.Errorf("merge: enums.%s.%s in %s was already found previously while parsing, duplicates are not allowed", e.Name, entry.Name, yamlPath))
+					if entry != nil {
+						if slices.ContainsFunc(prevEnum.Entries, func(e *EnumEntry) bool { return e != nil && e.Name == entry.Name }) {
+							errs = errors.Join(errs, fmt.Errorf("merge: enums.%s.%s in %s was already found previously while parsing, duplicates are not allowed", e.Name, entry.Name, yamlPath))
+						}
+						prevEnum.Entries = append(prevEnum.Entries, entry)
 					}
-					prevEnum.Entries = append(prevEnum.Entries, entry)
 				}
 				enums[e.Name] = prevEnum
 			} else {

--- a/gen/yml.go
+++ b/gen/yml.go
@@ -35,10 +35,10 @@ type Typedef struct {
 }
 
 type Enum struct {
-	Name     string      `yaml:"name"`
-	Doc      string      `yaml:"doc"`
-	Entries  []EnumEntry `yaml:"entries"`
-	Extended bool        `yaml:"extended"`
+	Name     string       `yaml:"name"`
+	Doc      string       `yaml:"doc"`
+	Entries  []*EnumEntry `yaml:"entries"`
+	Extended bool         `yaml:"extended"`
 }
 type EnumEntry struct {
 	Name  string `yaml:"name"`

--- a/schema.json
+++ b/schema.json
@@ -282,23 +282,31 @@
                     "entries": {
                         "type": "array",
                         "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "$ref": "#/definitions/Name",
-                                    "description": "Name of the enum entry"
+                            "anyOf": [
+                                {
+                                    "type": "null",
+                                    "description": "Reserves a space in the enum numbering"
                                 },
-                                "doc": {
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "$ref": "#/definitions/Value16",
-                                    "description": "Optional property, a 16-bit unsigned integer"
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "$ref": "#/definitions/Name",
+                                            "description": "Name of the enum entry"
+                                        },
+                                        "doc": {
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "$ref": "#/definitions/Value16",
+                                            "description": "Optional property, a 16-bit unsigned integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "name",
+                                        "doc"
+                                    ]
                                 }
-                            },
-                            "required": [
-                                "name",
-                                "doc"
                             ]
                         }
                     }

--- a/webgpu.h
+++ b/webgpu.h
@@ -274,9 +274,14 @@ typedef enum WGPUAdapterType {
 } WGPUAdapterType WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUAddressMode {
-    WGPUAddressMode_Repeat = 0x00000000,
-    WGPUAddressMode_MirrorRepeat = 0x00000001,
-    WGPUAddressMode_ClampToEdge = 0x00000002,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUAddressMode_Undefined = 0x00000000,
+    WGPUAddressMode_Repeat = 0x00000001,
+    WGPUAddressMode_MirrorRepeat = 0x00000002,
+    WGPUAddressMode_ClampToEdge = 0x00000003,
     WGPUAddressMode_Force32 = 0x7FFFFFFF
 } WGPUAddressMode WGPU_ENUM_ATTRIBUTE;
 
@@ -298,28 +303,38 @@ typedef enum WGPUBackendType {
 } WGPUBackendType WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUBlendFactor {
-    WGPUBlendFactor_Zero = 0x00000000,
-    WGPUBlendFactor_One = 0x00000001,
-    WGPUBlendFactor_Src = 0x00000002,
-    WGPUBlendFactor_OneMinusSrc = 0x00000003,
-    WGPUBlendFactor_SrcAlpha = 0x00000004,
-    WGPUBlendFactor_OneMinusSrcAlpha = 0x00000005,
-    WGPUBlendFactor_Dst = 0x00000006,
-    WGPUBlendFactor_OneMinusDst = 0x00000007,
-    WGPUBlendFactor_DstAlpha = 0x00000008,
-    WGPUBlendFactor_OneMinusDstAlpha = 0x00000009,
-    WGPUBlendFactor_SrcAlphaSaturated = 0x0000000A,
-    WGPUBlendFactor_Constant = 0x0000000B,
-    WGPUBlendFactor_OneMinusConstant = 0x0000000C,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUBlendFactor_Undefined = 0x00000000,
+    WGPUBlendFactor_Zero = 0x00000001,
+    WGPUBlendFactor_One = 0x00000002,
+    WGPUBlendFactor_Src = 0x00000003,
+    WGPUBlendFactor_OneMinusSrc = 0x00000004,
+    WGPUBlendFactor_SrcAlpha = 0x00000005,
+    WGPUBlendFactor_OneMinusSrcAlpha = 0x00000006,
+    WGPUBlendFactor_Dst = 0x00000007,
+    WGPUBlendFactor_OneMinusDst = 0x00000008,
+    WGPUBlendFactor_DstAlpha = 0x00000009,
+    WGPUBlendFactor_OneMinusDstAlpha = 0x0000000A,
+    WGPUBlendFactor_SrcAlphaSaturated = 0x0000000B,
+    WGPUBlendFactor_Constant = 0x0000000C,
+    WGPUBlendFactor_OneMinusConstant = 0x0000000D,
     WGPUBlendFactor_Force32 = 0x7FFFFFFF
 } WGPUBlendFactor WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUBlendOperation {
-    WGPUBlendOperation_Add = 0x00000000,
-    WGPUBlendOperation_Subtract = 0x00000001,
-    WGPUBlendOperation_ReverseSubtract = 0x00000002,
-    WGPUBlendOperation_Min = 0x00000003,
-    WGPUBlendOperation_Max = 0x00000004,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUBlendOperation_Undefined = 0x00000000,
+    WGPUBlendOperation_Add = 0x00000001,
+    WGPUBlendOperation_Subtract = 0x00000002,
+    WGPUBlendOperation_ReverseSubtract = 0x00000003,
+    WGPUBlendOperation_Min = 0x00000004,
+    WGPUBlendOperation_Max = 0x00000005,
     WGPUBlendOperation_Force32 = 0x7FFFFFFF
 } WGPUBlendOperation WGPU_ENUM_ATTRIBUTE;
 
@@ -458,9 +473,14 @@ typedef enum WGPUCreatePipelineAsyncStatus {
 } WGPUCreatePipelineAsyncStatus WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUCullMode {
-    WGPUCullMode_None = 0x00000000,
-    WGPUCullMode_Front = 0x00000001,
-    WGPUCullMode_Back = 0x00000002,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUCullMode_Undefined = 0x00000000,
+    WGPUCullMode_None = 0x00000001,
+    WGPUCullMode_Front = 0x00000002,
+    WGPUCullMode_Back = 0x00000003,
     WGPUCullMode_Force32 = 0x7FFFFFFF
 } WGPUCullMode WGPU_ENUM_ATTRIBUTE;
 
@@ -508,14 +528,24 @@ typedef enum WGPUFeatureName {
 } WGPUFeatureName WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUFilterMode {
-    WGPUFilterMode_Nearest = 0x00000000,
-    WGPUFilterMode_Linear = 0x00000001,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUFilterMode_Undefined = 0x00000000,
+    WGPUFilterMode_Nearest = 0x00000001,
+    WGPUFilterMode_Linear = 0x00000002,
     WGPUFilterMode_Force32 = 0x7FFFFFFF
 } WGPUFilterMode WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUFrontFace {
-    WGPUFrontFace_CCW = 0x00000000,
-    WGPUFrontFace_CW = 0x00000001,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUFrontFace_Undefined = 0x00000000,
+    WGPUFrontFace_CCW = 0x00000001,
+    WGPUFrontFace_CW = 0x00000002,
     WGPUFrontFace_Force32 = 0x7FFFFFFF
 } WGPUFrontFace WGPU_ENUM_ATTRIBUTE;
 
@@ -551,8 +581,13 @@ typedef enum WGPUMapAsyncStatus {
 } WGPUMapAsyncStatus WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUMipmapFilterMode {
-    WGPUMipmapFilterMode_Nearest = 0x00000000,
-    WGPUMipmapFilterMode_Linear = 0x00000001,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUMipmapFilterMode_Undefined = 0x00000000,
+    WGPUMipmapFilterMode_Nearest = 0x00000001,
+    WGPUMipmapFilterMode_Linear = 0x00000002,
     WGPUMipmapFilterMode_Force32 = 0x7FFFFFFF
 } WGPUMipmapFilterMode WGPU_ENUM_ATTRIBUTE;
 
@@ -619,11 +654,16 @@ typedef enum WGPUPresentMode {
 } WGPUPresentMode WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUPrimitiveTopology {
-    WGPUPrimitiveTopology_PointList = 0x00000000,
-    WGPUPrimitiveTopology_LineList = 0x00000001,
-    WGPUPrimitiveTopology_LineStrip = 0x00000002,
-    WGPUPrimitiveTopology_TriangleList = 0x00000003,
-    WGPUPrimitiveTopology_TriangleStrip = 0x00000004,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUPrimitiveTopology_Undefined = 0x00000000,
+    WGPUPrimitiveTopology_PointList = 0x00000001,
+    WGPUPrimitiveTopology_LineList = 0x00000002,
+    WGPUPrimitiveTopology_LineStrip = 0x00000003,
+    WGPUPrimitiveTopology_TriangleList = 0x00000004,
+    WGPUPrimitiveTopology_TriangleStrip = 0x00000005,
     WGPUPrimitiveTopology_Force32 = 0x7FFFFFFF
 } WGPUPrimitiveTopology WGPU_ENUM_ATTRIBUTE;
 
@@ -704,14 +744,19 @@ typedef enum WGPUStatus {
 } WGPUStatus WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUStencilOperation {
-    WGPUStencilOperation_Keep = 0x00000000,
-    WGPUStencilOperation_Zero = 0x00000001,
-    WGPUStencilOperation_Replace = 0x00000002,
-    WGPUStencilOperation_Invert = 0x00000003,
-    WGPUStencilOperation_IncrementClamp = 0x00000004,
-    WGPUStencilOperation_DecrementClamp = 0x00000005,
-    WGPUStencilOperation_IncrementWrap = 0x00000006,
-    WGPUStencilOperation_DecrementWrap = 0x00000007,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUStencilOperation_Undefined = 0x00000000,
+    WGPUStencilOperation_Keep = 0x00000001,
+    WGPUStencilOperation_Zero = 0x00000002,
+    WGPUStencilOperation_Replace = 0x00000003,
+    WGPUStencilOperation_Invert = 0x00000004,
+    WGPUStencilOperation_IncrementClamp = 0x00000005,
+    WGPUStencilOperation_DecrementClamp = 0x00000006,
+    WGPUStencilOperation_IncrementWrap = 0x00000007,
+    WGPUStencilOperation_DecrementWrap = 0x00000008,
     WGPUStencilOperation_Force32 = 0x7FFFFFFF
 } WGPUStencilOperation WGPU_ENUM_ATTRIBUTE;
 
@@ -788,16 +833,26 @@ typedef enum WGPUSurfaceGetCurrentTextureStatus {
 } WGPUSurfaceGetCurrentTextureStatus WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUTextureAspect {
-    WGPUTextureAspect_All = 0x00000000,
-    WGPUTextureAspect_StencilOnly = 0x00000001,
-    WGPUTextureAspect_DepthOnly = 0x00000002,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUTextureAspect_Undefined = 0x00000000,
+    WGPUTextureAspect_All = 0x00000001,
+    WGPUTextureAspect_StencilOnly = 0x00000002,
+    WGPUTextureAspect_DepthOnly = 0x00000003,
     WGPUTextureAspect_Force32 = 0x7FFFFFFF
 } WGPUTextureAspect WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUTextureDimension {
-    WGPUTextureDimension_1D = 0x00000000,
-    WGPUTextureDimension_2D = 0x00000001,
-    WGPUTextureDimension_3D = 0x00000002,
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUTextureDimension_Undefined = 0x00000000,
+    WGPUTextureDimension_1D = 0x00000001,
+    WGPUTextureDimension_2D = 0x00000002,
+    WGPUTextureDimension_3D = 0x00000003,
     WGPUTextureDimension_Force32 = 0x7FFFFFFF
 } WGPUTextureDimension WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.h
+++ b/webgpu.h
@@ -276,7 +276,7 @@ typedef enum WGPUAdapterType {
 typedef enum WGPUAddressMode {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUAddressMode_Undefined = 0x00000000,
     WGPUAddressMode_ClampToEdge = 0x00000001,
@@ -288,7 +288,7 @@ typedef enum WGPUAddressMode {
 typedef enum WGPUBackendType {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUBackendType_Undefined = 0x00000000,
     WGPUBackendType_Null = 0x00000001,
@@ -305,7 +305,7 @@ typedef enum WGPUBackendType {
 typedef enum WGPUBlendFactor {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUBlendFactor_Undefined = 0x00000000,
     WGPUBlendFactor_Zero = 0x00000001,
@@ -327,7 +327,7 @@ typedef enum WGPUBlendFactor {
 typedef enum WGPUBlendOperation {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUBlendOperation_Undefined = 0x00000000,
     WGPUBlendOperation_Add = 0x00000001,
@@ -348,7 +348,7 @@ typedef enum WGPUBufferBindingType {
     WGPUBufferBindingType_BindingNotUsed = 0x00000000,
     /**
      * `0x00000001`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUBufferBindingType_Undefined = 0x00000001,
     WGPUBufferBindingType_Uniform = 0x00000002,
@@ -399,7 +399,7 @@ typedef enum WGPUCallbackMode {
 typedef enum WGPUCompareFunction {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUCompareFunction_Undefined = 0x00000000,
     WGPUCompareFunction_Never = 0x00000001,
@@ -475,7 +475,7 @@ typedef enum WGPUCreatePipelineAsyncStatus {
 typedef enum WGPUCullMode {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUCullMode_Undefined = 0x00000000,
     WGPUCullMode_None = 0x00000001,
@@ -530,7 +530,7 @@ typedef enum WGPUFeatureName {
 typedef enum WGPUFilterMode {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUFilterMode_Undefined = 0x00000000,
     WGPUFilterMode_Nearest = 0x00000001,
@@ -541,7 +541,7 @@ typedef enum WGPUFilterMode {
 typedef enum WGPUFrontFace {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUFrontFace_Undefined = 0x00000000,
     WGPUFrontFace_CCW = 0x00000001,
@@ -552,7 +552,7 @@ typedef enum WGPUFrontFace {
 typedef enum WGPUIndexFormat {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUIndexFormat_Undefined = 0x00000000,
     WGPUIndexFormat_Uint16 = 0x00000001,
@@ -563,7 +563,7 @@ typedef enum WGPUIndexFormat {
 typedef enum WGPULoadOp {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPULoadOp_Undefined = 0x00000000,
     WGPULoadOp_Load = 0x00000001,
@@ -583,7 +583,7 @@ typedef enum WGPUMapAsyncStatus {
 typedef enum WGPUMipmapFilterMode {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUMipmapFilterMode_Undefined = 0x00000000,
     WGPUMipmapFilterMode_Nearest = 0x00000001,
@@ -656,7 +656,7 @@ typedef enum WGPUPresentMode {
 typedef enum WGPUPrimitiveTopology {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUPrimitiveTopology_Undefined = 0x00000000,
     WGPUPrimitiveTopology_PointList = 0x00000001,
@@ -722,7 +722,7 @@ typedef enum WGPUSamplerBindingType {
     WGPUSamplerBindingType_BindingNotUsed = 0x00000000,
     /**
      * `0x00000001`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUSamplerBindingType_Undefined = 0x00000001,
     WGPUSamplerBindingType_Filtering = 0x00000002,
@@ -745,7 +745,7 @@ typedef enum WGPUStatus {
 typedef enum WGPUStencilOperation {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUStencilOperation_Undefined = 0x00000000,
     WGPUStencilOperation_Keep = 0x00000001,
@@ -769,7 +769,7 @@ typedef enum WGPUStorageTextureAccess {
     WGPUStorageTextureAccess_BindingNotUsed = 0x00000000,
     /**
      * `0x00000001`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUStorageTextureAccess_Undefined = 0x00000001,
     WGPUStorageTextureAccess_WriteOnly = 0x00000002,
@@ -781,7 +781,7 @@ typedef enum WGPUStorageTextureAccess {
 typedef enum WGPUStoreOp {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUStoreOp_Undefined = 0x00000000,
     WGPUStoreOp_Store = 0x00000001,
@@ -834,7 +834,7 @@ typedef enum WGPUSurfaceGetCurrentTextureStatus {
 typedef enum WGPUTextureAspect {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUTextureAspect_Undefined = 0x00000000,
     WGPUTextureAspect_All = 0x00000001,
@@ -846,7 +846,7 @@ typedef enum WGPUTextureAspect {
 typedef enum WGPUTextureDimension {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUTextureDimension_Undefined = 0x00000000,
     WGPUTextureDimension_1D = 0x00000001,
@@ -858,7 +858,7 @@ typedef enum WGPUTextureDimension {
 typedef enum WGPUTextureFormat {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUTextureFormat_Undefined = 0x00000000,
     WGPUTextureFormat_R8Unorm = 0x00000001,
@@ -969,7 +969,7 @@ typedef enum WGPUTextureSampleType {
     WGPUTextureSampleType_BindingNotUsed = 0x00000000,
     /**
      * `0x00000001`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUTextureSampleType_Undefined = 0x00000001,
     WGPUTextureSampleType_Float = 0x00000002,
@@ -983,7 +983,7 @@ typedef enum WGPUTextureSampleType {
 typedef enum WGPUTextureViewDimension {
     /**
      * `0x00000000`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUTextureViewDimension_Undefined = 0x00000000,
     WGPUTextureViewDimension_1D = 0x00000001,
@@ -1039,7 +1039,7 @@ typedef enum WGPUVertexStepMode {
     WGPUVertexStepMode_VertexBufferNotUsed = 0x00000000,
     /**
      * `0x00000001`.
-     * No value. See @ref SentinelValues.
+     * Indicates no value is passed for this argument. See @ref SentinelValues.
      */
     WGPUVertexStepMode_Undefined = 0x00000001,
     WGPUVertexStepMode_Vertex = 0x00000002,

--- a/webgpu.h
+++ b/webgpu.h
@@ -324,10 +324,21 @@ typedef enum WGPUBlendOperation {
 } WGPUBlendOperation WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUBufferBindingType {
-    WGPUBufferBindingType_Undefined = 0x00000000,
-    WGPUBufferBindingType_Uniform = 0x00000001,
-    WGPUBufferBindingType_Storage = 0x00000002,
-    WGPUBufferBindingType_ReadOnlyStorage = 0x00000003,
+    /**
+     * `0x00000000`.
+     * Indicates that this @ref WGPUBufferBindingLayout member of
+     * its parent @ref WGPUBindGroupLayoutEntry is not used.
+     * (See also @ref SentinelValues.)
+     */
+    WGPUBufferBindingType_BindingNotUsed = 0x00000000,
+    /**
+     * `0x00000001`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUBufferBindingType_Undefined = 0x00000001,
+    WGPUBufferBindingType_Uniform = 0x00000002,
+    WGPUBufferBindingType_Storage = 0x00000003,
+    WGPUBufferBindingType_ReadOnlyStorage = 0x00000004,
     WGPUBufferBindingType_Force32 = 0x7FFFFFFF
 } WGPUBufferBindingType WGPU_ENUM_ATTRIBUTE;
 
@@ -663,10 +674,21 @@ typedef enum WGPUSType {
 } WGPUSType WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUSamplerBindingType {
-    WGPUSamplerBindingType_Undefined = 0x00000000,
-    WGPUSamplerBindingType_Filtering = 0x00000001,
-    WGPUSamplerBindingType_NonFiltering = 0x00000002,
-    WGPUSamplerBindingType_Comparison = 0x00000003,
+    /**
+     * `0x00000000`.
+     * Indicates that this @ref WGPUSamplerBindingLayout member of
+     * its parent @ref WGPUBindGroupLayoutEntry is not used.
+     * (See also @ref SentinelValues.)
+     */
+    WGPUSamplerBindingType_BindingNotUsed = 0x00000000,
+    /**
+     * `0x00000001`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUSamplerBindingType_Undefined = 0x00000001,
+    WGPUSamplerBindingType_Filtering = 0x00000002,
+    WGPUSamplerBindingType_NonFiltering = 0x00000003,
+    WGPUSamplerBindingType_Comparison = 0x00000004,
     WGPUSamplerBindingType_Force32 = 0x7FFFFFFF
 } WGPUSamplerBindingType WGPU_ENUM_ATTRIBUTE;
 
@@ -694,10 +716,21 @@ typedef enum WGPUStencilOperation {
 } WGPUStencilOperation WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUStorageTextureAccess {
-    WGPUStorageTextureAccess_Undefined = 0x00000000,
-    WGPUStorageTextureAccess_WriteOnly = 0x00000001,
-    WGPUStorageTextureAccess_ReadOnly = 0x00000002,
-    WGPUStorageTextureAccess_ReadWrite = 0x00000003,
+    /**
+     * `0x00000000`.
+     * Indicates that this @ref WGPUStorageTextureBindingLayout member of
+     * its parent @ref WGPUBindGroupLayoutEntry is not used.
+     * (See also @ref SentinelValues.)
+     */
+    WGPUStorageTextureAccess_BindingNotUsed = 0x00000000,
+    /**
+     * `0x00000001`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUStorageTextureAccess_Undefined = 0x00000001,
+    WGPUStorageTextureAccess_WriteOnly = 0x00000002,
+    WGPUStorageTextureAccess_ReadOnly = 0x00000003,
+    WGPUStorageTextureAccess_ReadWrite = 0x00000004,
     WGPUStorageTextureAccess_Force32 = 0x7FFFFFFF
 } WGPUStorageTextureAccess WGPU_ENUM_ATTRIBUTE;
 
@@ -873,12 +906,23 @@ typedef enum WGPUTextureFormat {
 } WGPUTextureFormat WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUTextureSampleType {
-    WGPUTextureSampleType_Undefined = 0x00000000,
-    WGPUTextureSampleType_Float = 0x00000001,
-    WGPUTextureSampleType_UnfilterableFloat = 0x00000002,
-    WGPUTextureSampleType_Depth = 0x00000003,
-    WGPUTextureSampleType_Sint = 0x00000004,
-    WGPUTextureSampleType_Uint = 0x00000005,
+    /**
+     * `0x00000000`.
+     * Indicates that this @ref WGPUTextureBindingLayout member of
+     * its parent @ref WGPUBindGroupLayoutEntry is not used.
+     * (See also @ref SentinelValues.)
+     */
+    WGPUTextureSampleType_BindingNotUsed = 0x00000000,
+    /**
+     * `0x00000001`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUTextureSampleType_Undefined = 0x00000001,
+    WGPUTextureSampleType_Float = 0x00000002,
+    WGPUTextureSampleType_UnfilterableFloat = 0x00000003,
+    WGPUTextureSampleType_Depth = 0x00000004,
+    WGPUTextureSampleType_Sint = 0x00000005,
+    WGPUTextureSampleType_Uint = 0x00000006,
     WGPUTextureSampleType_Force32 = 0x7FFFFFFF
 } WGPUTextureSampleType WGPU_ENUM_ATTRIBUTE;
 
@@ -934,9 +978,19 @@ typedef enum WGPUVertexFormat {
 } WGPUVertexFormat WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUVertexStepMode {
-    WGPUVertexStepMode_Vertex = 0x00000000,
-    WGPUVertexStepMode_Instance = 0x00000001,
-    WGPUVertexStepMode_VertexBufferNotUsed = 0x00000002,
+    /**
+     * `0x00000000`.
+     * This @ref WGPUVertexBufferLayout is a "hole" in the @ref WGPUVertexState `buffers` array.
+     * (See also @ref SentinelValues.)
+     */
+    WGPUVertexStepMode_VertexBufferNotUsed = 0x00000000,
+    /**
+     * `0x00000001`.
+     * No value. See @ref SentinelValues.
+     */
+    WGPUVertexStepMode_Undefined = 0x00000001,
+    WGPUVertexStepMode_Vertex = 0x00000002,
+    WGPUVertexStepMode_Instance = 0x00000003,
     WGPUVertexStepMode_Force32 = 0x7FFFFFFF
 } WGPUVertexStepMode WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.h
+++ b/webgpu.h
@@ -279,9 +279,9 @@ typedef enum WGPUAddressMode {
      * No value. See @ref SentinelValues.
      */
     WGPUAddressMode_Undefined = 0x00000000,
-    WGPUAddressMode_Repeat = 0x00000001,
-    WGPUAddressMode_MirrorRepeat = 0x00000002,
-    WGPUAddressMode_ClampToEdge = 0x00000003,
+    WGPUAddressMode_ClampToEdge = 0x00000001,
+    WGPUAddressMode_Repeat = 0x00000002,
+    WGPUAddressMode_MirrorRepeat = 0x00000003,
     WGPUAddressMode_Force32 = 0x7FFFFFFF
 } WGPUAddressMode WGPU_ENUM_ATTRIBUTE;
 
@@ -404,11 +404,11 @@ typedef enum WGPUCompareFunction {
     WGPUCompareFunction_Undefined = 0x00000000,
     WGPUCompareFunction_Never = 0x00000001,
     WGPUCompareFunction_Less = 0x00000002,
-    WGPUCompareFunction_LessEqual = 0x00000003,
-    WGPUCompareFunction_Greater = 0x00000004,
-    WGPUCompareFunction_GreaterEqual = 0x00000005,
-    WGPUCompareFunction_Equal = 0x00000006,
-    WGPUCompareFunction_NotEqual = 0x00000007,
+    WGPUCompareFunction_Equal = 0x00000003,
+    WGPUCompareFunction_LessEqual = 0x00000004,
+    WGPUCompareFunction_Greater = 0x00000005,
+    WGPUCompareFunction_NotEqual = 0x00000006,
+    WGPUCompareFunction_GreaterEqual = 0x00000007,
     WGPUCompareFunction_Always = 0x00000008,
     WGPUCompareFunction_Force32 = 0x7FFFFFFF
 } WGPUCompareFunction WGPU_ENUM_ATTRIBUTE;

--- a/webgpu.h
+++ b/webgpu.h
@@ -266,10 +266,10 @@ struct WGPUUncapturedErrorCallbackInfo;
  * @{
  */
 typedef enum WGPUAdapterType {
-    WGPUAdapterType_DiscreteGPU = 0x00000000,
-    WGPUAdapterType_IntegratedGPU = 0x00000001,
-    WGPUAdapterType_CPU = 0x00000002,
-    WGPUAdapterType_Unknown = 0x00000003,
+    WGPUAdapterType_DiscreteGPU = 0x00000001,
+    WGPUAdapterType_IntegratedGPU = 0x00000002,
+    WGPUAdapterType_CPU = 0x00000003,
+    WGPUAdapterType_Unknown = 0x00000004,
     WGPUAdapterType_Force32 = 0x7FFFFFFF
 } WGPUAdapterType WGPU_ENUM_ATTRIBUTE;
 
@@ -358,9 +358,9 @@ typedef enum WGPUBufferBindingType {
 } WGPUBufferBindingType WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUBufferMapState {
-    WGPUBufferMapState_Unmapped = 0x00000000,
-    WGPUBufferMapState_Pending = 0x00000001,
-    WGPUBufferMapState_Mapped = 0x00000002,
+    WGPUBufferMapState_Unmapped = 0x00000001,
+    WGPUBufferMapState_Pending = 0x00000002,
+    WGPUBufferMapState_Mapped = 0x00000003,
     WGPUBufferMapState_Force32 = 0x7FFFFFFF
 } WGPUBufferMapState WGPU_ENUM_ATTRIBUTE;
 
@@ -423,9 +423,9 @@ typedef enum WGPUCompilationInfoRequestStatus {
 } WGPUCompilationInfoRequestStatus WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUCompilationMessageType {
-    WGPUCompilationMessageType_Error = 0x00000000,
-    WGPUCompilationMessageType_Warning = 0x00000001,
-    WGPUCompilationMessageType_Info = 0x00000002,
+    WGPUCompilationMessageType_Error = 0x00000001,
+    WGPUCompilationMessageType_Warning = 0x00000002,
+    WGPUCompilationMessageType_Info = 0x00000003,
     WGPUCompilationMessageType_Force32 = 0x7FFFFFFF
 } WGPUCompilationMessageType WGPU_ENUM_ATTRIBUTE;
 
@@ -493,19 +493,19 @@ typedef enum WGPUDeviceLostReason {
 } WGPUDeviceLostReason WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUErrorFilter {
-    WGPUErrorFilter_Validation = 0x00000000,
-    WGPUErrorFilter_OutOfMemory = 0x00000001,
-    WGPUErrorFilter_Internal = 0x00000002,
+    WGPUErrorFilter_Validation = 0x00000001,
+    WGPUErrorFilter_OutOfMemory = 0x00000002,
+    WGPUErrorFilter_Internal = 0x00000003,
     WGPUErrorFilter_Force32 = 0x7FFFFFFF
 } WGPUErrorFilter WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUErrorType {
-    WGPUErrorType_NoError = 0x00000000,
-    WGPUErrorType_Validation = 0x00000001,
-    WGPUErrorType_OutOfMemory = 0x00000002,
-    WGPUErrorType_Internal = 0x00000003,
-    WGPUErrorType_Unknown = 0x00000004,
-    WGPUErrorType_DeviceLost = 0x00000005,
+    WGPUErrorType_NoError = 0x00000001,
+    WGPUErrorType_Validation = 0x00000002,
+    WGPUErrorType_OutOfMemory = 0x00000003,
+    WGPUErrorType_Internal = 0x00000004,
+    WGPUErrorType_Unknown = 0x00000005,
+    WGPUErrorType_DeviceLost = 0x00000006,
     WGPUErrorType_Force32 = 0x7FFFFFFF
 } WGPUErrorType WGPU_ENUM_ATTRIBUTE;
 
@@ -668,8 +668,8 @@ typedef enum WGPUPrimitiveTopology {
 } WGPUPrimitiveTopology WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUQueryType {
-    WGPUQueryType_Occlusion = 0x00000000,
-    WGPUQueryType_Timestamp = 0x00000001,
+    WGPUQueryType_Occlusion = 0x00000001,
+    WGPUQueryType_Timestamp = 0x00000002,
     WGPUQueryType_Force32 = 0x7FFFFFFF
 } WGPUQueryType WGPU_ENUM_ATTRIBUTE;
 
@@ -700,7 +700,6 @@ typedef enum WGPURequestDeviceStatus {
 } WGPURequestDeviceStatus WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUSType {
-    WGPUSType_Invalid = 0x00000000,
     WGPUSType_ShaderSourceSPIRV = 0x00000001,
     WGPUSType_ShaderSourceWGSL = 0x00000002,
     WGPUSType_RenderPassMaxDrawCount = 0x00000003,
@@ -738,8 +737,8 @@ typedef enum WGPUSamplerBindingType {
  * error. Read the function's documentation for specific error conditions.
  */
 typedef enum WGPUStatus {
-    WGPUStatus_Success = 0x00000000,
-    WGPUStatus_Error = 0x00000001,
+    WGPUStatus_Success = 0x00000001,
+    WGPUStatus_Error = 0x00000002,
     WGPUStatus_Force32 = 0x7FFFFFFF
 } WGPUStatus WGPU_ENUM_ATTRIBUTE;
 
@@ -795,40 +794,40 @@ typedef enum WGPUStoreOp {
  */
 typedef enum WGPUSurfaceGetCurrentTextureStatus {
     /**
-     * `0x00000000`.
+     * `0x00000001`.
      * Yay! Everything is good and we can render this frame.
      */
-    WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal = 0x00000000,
-    /**
-     * `0x00000001`.
-     * Still OK - the surface can present the frame, but in a suboptimal way. The surface may need reconfiguration.
-     */
-    WGPUSurfaceGetCurrentTextureStatus_SuccessSuboptimal = 0x00000001,
+    WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal = 0x00000001,
     /**
      * `0x00000002`.
-     * Some operation timed out while trying to acquire the frame.
+     * Still OK - the surface can present the frame, but in a suboptimal way. The surface may need reconfiguration.
      */
-    WGPUSurfaceGetCurrentTextureStatus_Timeout = 0x00000002,
+    WGPUSurfaceGetCurrentTextureStatus_SuccessSuboptimal = 0x00000002,
     /**
      * `0x00000003`.
-     * The surface is too different to be used, compared to when it was originally created.
+     * Some operation timed out while trying to acquire the frame.
      */
-    WGPUSurfaceGetCurrentTextureStatus_Outdated = 0x00000003,
+    WGPUSurfaceGetCurrentTextureStatus_Timeout = 0x00000003,
     /**
      * `0x00000004`.
-     * The connection to whatever owns the surface was lost.
+     * The surface is too different to be used, compared to when it was originally created.
      */
-    WGPUSurfaceGetCurrentTextureStatus_Lost = 0x00000004,
+    WGPUSurfaceGetCurrentTextureStatus_Outdated = 0x00000004,
     /**
      * `0x00000005`.
-     * The system ran out of memory.
+     * The connection to whatever owns the surface was lost.
      */
-    WGPUSurfaceGetCurrentTextureStatus_OutOfMemory = 0x00000005,
+    WGPUSurfaceGetCurrentTextureStatus_Lost = 0x00000005,
     /**
      * `0x00000006`.
+     * The system ran out of memory.
+     */
+    WGPUSurfaceGetCurrentTextureStatus_OutOfMemory = 0x00000006,
+    /**
+     * `0x00000007`.
      * The @ref WGPUDevice configured on the @ref WGPUSurface was lost.
      */
-    WGPUSurfaceGetCurrentTextureStatus_DeviceLost = 0x00000006,
+    WGPUSurfaceGetCurrentTextureStatus_DeviceLost = 0x00000007,
     WGPUSurfaceGetCurrentTextureStatus_Force32 = 0x7FFFFFFF
 } WGPUSurfaceGetCurrentTextureStatus WGPU_ENUM_ATTRIBUTE;
 
@@ -997,7 +996,6 @@ typedef enum WGPUTextureViewDimension {
 } WGPUTextureViewDimension WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUVertexFormat {
-    WGPUVertexFormat_Undefined = 0x00000000,
     WGPUVertexFormat_Uint8x2 = 0x00000001,
     WGPUVertexFormat_Uint8x4 = 0x00000002,
     WGPUVertexFormat_Sint8x2 = 0x00000003,
@@ -1050,7 +1048,6 @@ typedef enum WGPUVertexStepMode {
 } WGPUVertexStepMode WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUWGSLFeatureName {
-    WGPUWGSLFeatureName_Undefined = 0x00000000,
     WGPUWGSLFeatureName_ReadonlyAndReadwriteStorageTextures = 0x00000001,
     WGPUWGSLFeatureName_Packed4x8IntegerDotProduct = 0x00000002,
     WGPUWGSLFeatureName_UnrestrictedPointerParameters = 0x00000003,
@@ -1063,30 +1060,30 @@ typedef enum WGPUWGSLFeatureName {
  */
 typedef enum WGPUWaitStatus {
     /**
-     * `0x00000000`.
+     * `0x00000001`.
      * At least one WGPUFuture completed successfully.
      */
-    WGPUWaitStatus_Success = 0x00000000,
-    /**
-     * `0x00000001`.
-     * No WGPUFutures completed within the timeout.
-     */
-    WGPUWaitStatus_TimedOut = 0x00000001,
+    WGPUWaitStatus_Success = 0x00000001,
     /**
      * `0x00000002`.
-     * A @ref Timed-Wait was performed when WGPUInstanceFeatures::timedWaitAnyEnable is false.
+     * No WGPUFutures completed within the timeout.
      */
-    WGPUWaitStatus_UnsupportedTimeout = 0x00000002,
+    WGPUWaitStatus_TimedOut = 0x00000002,
     /**
      * `0x00000003`.
-     * The number of futures waited on in a @ref Timed-Wait is greater than the supported WGPUInstanceFeatures::timedWaitAnyMaxCount.
+     * A @ref Timed-Wait was performed when WGPUInstanceFeatures::timedWaitAnyEnable is false.
      */
-    WGPUWaitStatus_UnsupportedCount = 0x00000003,
+    WGPUWaitStatus_UnsupportedTimeout = 0x00000003,
     /**
      * `0x00000004`.
+     * The number of futures waited on in a @ref Timed-Wait is greater than the supported WGPUInstanceFeatures::timedWaitAnyMaxCount.
+     */
+    WGPUWaitStatus_UnsupportedCount = 0x00000004,
+    /**
+     * `0x00000005`.
      * An invalid wait was performed with @ref Mixed-Sources.
      */
-    WGPUWaitStatus_UnsupportedMixedSources = 0x00000004,
+    WGPUWaitStatus_UnsupportedMixedSources = 0x00000005,
     WGPUWaitStatus_Force32 = 0x7FFFFFFF
 } WGPUWaitStatus WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.h
+++ b/webgpu.h
@@ -281,6 +281,10 @@ typedef enum WGPUAddressMode {
 } WGPUAddressMode WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUBackendType {
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
     WGPUBackendType_Undefined = 0x00000000,
     WGPUBackendType_Null = 0x00000001,
     WGPUBackendType_WebGPU = 0x00000002,
@@ -367,6 +371,10 @@ typedef enum WGPUCallbackMode {
 } WGPUCallbackMode WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUCompareFunction {
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
     WGPUCompareFunction_Undefined = 0x00000000,
     WGPUCompareFunction_Never = 0x00000001,
     WGPUCompareFunction_Less = 0x00000002,
@@ -501,6 +509,10 @@ typedef enum WGPUFrontFace {
 } WGPUFrontFace WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUIndexFormat {
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
     WGPUIndexFormat_Undefined = 0x00000000,
     WGPUIndexFormat_Uint16 = 0x00000001,
     WGPUIndexFormat_Uint32 = 0x00000002,
@@ -508,6 +520,10 @@ typedef enum WGPUIndexFormat {
 } WGPUIndexFormat WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPULoadOp {
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
     WGPULoadOp_Undefined = 0x00000000,
     WGPULoadOp_Load = 0x00000001,
     WGPULoadOp_Clear = 0x00000002,
@@ -543,6 +559,10 @@ typedef enum WGPUPopErrorScopeStatus {
 } WGPUPopErrorScopeStatus WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUPowerPreference {
+    /**
+     * `0x00000000`.
+     * No preference. (See also @ref SentinelValues.)
+     */
     WGPUPowerPreference_Undefined = 0x00000000,
     WGPUPowerPreference_LowPower = 0x00000001,
     WGPUPowerPreference_HighPerformance = 0x00000002,
@@ -682,6 +702,10 @@ typedef enum WGPUStorageTextureAccess {
 } WGPUStorageTextureAccess WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUStoreOp {
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
     WGPUStoreOp_Undefined = 0x00000000,
     WGPUStoreOp_Store = 0x00000001,
     WGPUStoreOp_Discard = 0x00000002,
@@ -745,6 +769,10 @@ typedef enum WGPUTextureDimension {
 } WGPUTextureDimension WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUTextureFormat {
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
     WGPUTextureFormat_Undefined = 0x00000000,
     WGPUTextureFormat_R8Unorm = 0x00000001,
     WGPUTextureFormat_R8Snorm = 0x00000002,
@@ -855,6 +883,10 @@ typedef enum WGPUTextureSampleType {
 } WGPUTextureSampleType WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUTextureViewDimension {
+    /**
+     * `0x00000000`.
+     * No value. See @ref SentinelValues.
+     */
     WGPUTextureViewDimension_Undefined = 0x00000000,
     WGPUTextureViewDimension_1D = 0x00000001,
     WGPUTextureViewDimension_2D = 0x00000002,
@@ -1829,8 +1861,13 @@ typedef struct WGPUTextureDescriptor {
 } WGPUTextureDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUVertexBufferLayout {
-    uint64_t arrayStride;
+    /**
+     * The step mode for the vertex buffer. If @ref WGPUVertexStepMode_VertexBufferNotUsed,
+     * indicates a "hole" in the parent @ref WGPUVertexState `buffers` array:
+     * the pipeline does not use a vertex buffer at this `location`.
+     */
     WGPUVertexStepMode stepMode;
+    uint64_t arrayStride;
     size_t attributeCount;
     WGPUVertexAttribute const * attributes;
 } WGPUVertexBufferLayout WGPU_STRUCTURE_ATTRIBUTE;
@@ -1847,6 +1884,11 @@ typedef struct WGPUBindGroupLayoutDescriptor {
 
 typedef struct WGPUColorTargetState {
     WGPUChainedStruct const * nextInChain;
+    /**
+     * The texture format of the target. If @ref WGPUTextureFormat_Undefined,
+     * indicates a "hole" in the parent @ref WGPUFragmentState `targets` array:
+     * the pipeline does not output a value at this `location`.
+     */
     WGPUTextureFormat format;
     WGPU_NULLABLE WGPUBlendState const * blend;
     WGPUColorWriteMask writeMask;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -77,8 +77,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: |
-          TODO
+        doc: No value. See @ref SentinelValues.
       - name: "null"
         doc: |
           TODO
@@ -224,8 +223,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: |
-          TODO
+        doc: No value. See @ref SentinelValues.
       - name: never
         doc: |
           TODO
@@ -471,8 +469,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: |
-          TODO
+        doc: No value. See @ref SentinelValues.
       - name: uint16
         doc: |
           TODO
@@ -484,8 +481,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: |
-          TODO
+        doc: No value. See @ref SentinelValues.
       - name: load
         doc: |
           TODO
@@ -556,8 +552,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: |
-          TODO
+        doc: No preference. (See also @ref SentinelValues.)
       - name: low_power
         doc: |
           TODO
@@ -795,8 +790,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: |
-          TODO
+        doc: No value. See @ref SentinelValues.
       - name: store
         doc: |
           TODO
@@ -851,8 +845,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: |
-          TODO
+        doc: No value. See @ref SentinelValues.
       - name: R8_unorm
         doc: |
           TODO
@@ -1165,8 +1158,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: |
-          TODO
+        doc: No value. See @ref SentinelValues.
       - name: 1D
         doc: |
           TODO
@@ -1674,7 +1666,9 @@ structs:
     members:
       - name: format
         doc: |
-          TODO
+          The texture format of the target. If @ref WGPUTextureFormat_Undefined,
+          indicates a "hole" in the parent @ref WGPUFragmentState `targets` array:
+          the pipeline does not output a value at this `location`.
         type: enum.texture_format
       - name: blend
         doc: |
@@ -2932,14 +2926,16 @@ structs:
       TODO
     type: standalone
     members:
+      - name: step_mode
+        doc: |
+          The step mode for the vertex buffer. If @ref WGPUVertexStepMode_VertexBufferNotUsed,
+          indicates a "hole" in the parent @ref WGPUVertexState `buffers` array:
+          the pipeline does not use a vertex buffer at this `location`.
+        type: enum.vertex_step_mode
       - name: array_stride
         doc: |
           TODO
         type: uint64
-      - name: step_mode
-        doc: |
-          TODO
-        type: enum.vertex_step_mode
       - name: attributes
         doc: |
           TODO

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -65,7 +65,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: clamp_to_edge
         doc: |
           TODO
@@ -80,7 +80,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: "null"
         doc: |
           TODO
@@ -110,7 +110,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: zero
         doc: |
           TODO
@@ -155,7 +155,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: add
         doc: |
           TODO
@@ -181,7 +181,7 @@ enums:
           its parent @ref WGPUBindGroupLayoutEntry is not used.
           (See also @ref SentinelValues.)
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: uniform
         doc: |
           TODO
@@ -233,7 +233,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: never
         doc: |
           TODO
@@ -336,7 +336,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: none
         doc: |
           TODO
@@ -451,7 +451,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: nearest
         doc: |
           TODO
@@ -463,7 +463,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: CCW
         doc: |
           TODO
@@ -475,7 +475,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: uint16
         doc: |
           TODO
@@ -487,7 +487,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: load
         doc: |
           TODO
@@ -519,7 +519,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: nearest
         doc: |
           TODO
@@ -591,7 +591,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: point_list
         doc: |
           TODO
@@ -718,7 +718,7 @@ enums:
           its parent @ref WGPUBindGroupLayoutEntry is not used.
           (See also @ref SentinelValues.)
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: filtering
         doc: |
           TODO
@@ -744,7 +744,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: keep
         doc: |
           TODO
@@ -779,7 +779,7 @@ enums:
           its parent @ref WGPUBindGroupLayoutEntry is not used.
           (See also @ref SentinelValues.)
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: write_only
         doc: |
           TODO
@@ -794,7 +794,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: store
         doc: |
           TODO
@@ -824,7 +824,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: all
         doc: |
           TODO
@@ -839,7 +839,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: 1D
         doc: |
           TODO
@@ -854,7 +854,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: R8_unorm
         doc: |
           TODO
@@ -1150,7 +1150,7 @@ enums:
           its parent @ref WGPUBindGroupLayoutEntry is not used.
           (See also @ref SentinelValues.)
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: float
         doc: |
           TODO
@@ -1171,7 +1171,7 @@ enums:
       TODO
     entries:
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: 1D
         doc: |
           TODO
@@ -1297,7 +1297,7 @@ enums:
           This @ref WGPUVertexBufferLayout is a "hole" in the @ref WGPUVertexState `buffers` array.
           (See also @ref SentinelValues.)
       - name: undefined
-        doc: No value. See @ref SentinelValues.
+        doc: Indicates no value is passed for this argument. See @ref SentinelValues.
       - name: vertex
         doc: |
           TODO

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -168,9 +168,13 @@ enums:
     doc: |
       TODO
     entries:
-      - name: undefined
+      - name: binding_not_used
         doc: |
-          TODO
+          Indicates that this @ref WGPUBufferBindingLayout member of
+          its parent @ref WGPUBindGroupLayoutEntry is not used.
+          (See also @ref SentinelValues.)
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: uniform
         doc: |
           TODO
@@ -719,9 +723,13 @@ enums:
     doc: |
       TODO
     entries:
-      - name: undefined
+      - name: binding_not_used
         doc: |
-          TODO
+          Indicates that this @ref WGPUSamplerBindingLayout member of
+          its parent @ref WGPUBindGroupLayoutEntry is not used.
+          (See also @ref SentinelValues.)
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: filtering
         doc: |
           TODO
@@ -773,9 +781,13 @@ enums:
     doc: |
       TODO
     entries:
-      - name: undefined
+      - name: binding_not_used
         doc: |
-          TODO
+          Indicates that this @ref WGPUStorageTextureBindingLayout member of
+          its parent @ref WGPUBindGroupLayoutEntry is not used.
+          (See also @ref SentinelValues.)
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: write_only
         doc: |
           TODO
@@ -1135,9 +1147,13 @@ enums:
     doc: |
       TODO
     entries:
-      - name: undefined
+      - name: binding_not_used
         doc: |
-          TODO
+          Indicates that this @ref WGPUTextureBindingLayout member of
+          its parent @ref WGPUBindGroupLayoutEntry is not used.
+          (See also @ref SentinelValues.)
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: float
         doc: |
           TODO
@@ -1281,13 +1297,16 @@ enums:
     doc: |
       TODO
     entries:
+      - name: vertex_buffer_not_used
+        doc: |
+          This @ref WGPUVertexBufferLayout is a "hole" in the @ref WGPUVertexState `buffers` array.
+          (See also @ref SentinelValues.)
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: vertex
         doc: |
           TODO
       - name: instance
-        doc: |
-          TODO
-      - name: vertex_buffer_not_used
         doc: |
           TODO
   - name: wait_status

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -63,6 +63,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: repeat
         doc: |
           TODO
@@ -106,6 +108,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: zero
         doc: |
           TODO
@@ -149,6 +153,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: add
         doc: |
           TODO
@@ -338,6 +344,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: none
         doc: |
           TODO
@@ -452,6 +460,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: nearest
         doc: |
           TODO
@@ -462,6 +472,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: CCW
         doc: |
           TODO
@@ -520,6 +532,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: nearest
         doc: |
           TODO
@@ -591,6 +605,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: point_list
         doc: |
           TODO
@@ -753,6 +769,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: keep
         doc: |
           TODO
@@ -830,6 +848,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: all
         doc: |
           TODO
@@ -843,6 +863,8 @@ enums:
     doc: |
       TODO
     entries:
+      - name: undefined
+        doc: No value. See @ref SentinelValues.
       - name: 1D
         doc: |
           TODO

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -66,13 +66,13 @@ enums:
     entries:
       - name: undefined
         doc: No value. See @ref SentinelValues.
+      - name: clamp_to_edge
+        doc: |
+          TODO
       - name: repeat
         doc: |
           TODO
       - name: mirror_repeat
-        doc: |
-          TODO
-      - name: clamp_to_edge
         doc: |
           TODO
   - name: backend_type
@@ -240,19 +240,19 @@ enums:
       - name: less
         doc: |
           TODO
+      - name: equal
+        doc: |
+          TODO
       - name: less_equal
         doc: |
           TODO
       - name: greater
         doc: |
           TODO
-      - name: greater_equal
-        doc: |
-          TODO
-      - name: equal
-        doc: |
-          TODO
       - name: not_equal
+        doc: |
+          TODO
+      - name: greater_equal
         doc: |
           TODO
       - name: always

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -47,6 +47,7 @@ enums:
     doc: |
       TODO
     entries:
+      - null
       - name: discrete_GPU
         doc: |
           TODO
@@ -194,6 +195,7 @@ enums:
     doc: |
       TODO
     entries:
+      - null
       - name: unmapped
         doc: |
           TODO
@@ -206,20 +208,18 @@ enums:
   - name: callback_mode
     doc: The callback mode controls how a callback for an asynchronous operation may be fired. See @ref Asynchronous-Operations for how these are used.
     entries:
+      - null
       - name: wait_any_only
-        value: 0x0001
         doc: |
           Callbacks created with `WGPUCallbackMode_WaitAnyOnly`:
           - fire when the asynchronous operation's future is passed to a call to `::wgpuInstanceWaitAny`
             AND the operation has already completed or it completes inside the call to `::wgpuInstanceWaitAny`.
       - name: allow_process_events
-        value: 0x0002
         doc: |
           Callbacks created with `WGPUCallbackMode_AllowProcessEvents`:
           - fire for the same reasons as callbacks created with `WGPUCallbackMode_WaitAnyOnly`
           - fire inside a call to `::wgpuInstanceProcessEvents` if the asynchronous operation is complete.
       - name: allow_spontaneous
-        value: 0x0003
         doc: |
           Callbacks created with `WGPUCallbackMode_AllowSpontaneous`:
           - fire for the same reasons as callbacks created with `WGPUCallbackMode_AllowProcessEvents`
@@ -262,30 +262,27 @@ enums:
     doc: |
       TODO
     entries:
+      - null
       - name: success
-        value: 0x0001
         doc: |
           TODO
       - name: instance_dropped
-        value: 0x0002
         doc: |
           TODO
       - name: error
-        value: 0x0003
         doc: |
           TODO
       - name: device_lost
-        value: 0x0004
         doc: |
           TODO
       - name: unknown
-        value: 0x0005
         doc: |
           TODO
   - name: compilation_message_type
     doc: |
       TODO
     entries:
+      - null
       - name: error
         doc: |
           TODO
@@ -312,32 +309,26 @@ enums:
     doc: |
       TODO
     entries:
+      - null
       - name: success
-        value: 0x0001
         doc: |
           TODO
       - name: instance_dropped
-        value: 0x0002
         doc: |
           TODO
       - name: validation_error
-        value: 0x0003
         doc: |
           TODO
       - name: internal_error
-        value: 0x0004
         doc: |
           TODO
       - name: device_lost
-        value: 0x0005
         doc: |
           TODO
       - name: device_destroyed
-        value: 0x0006
         doc: |
           TODO
       - name: unknown
-        value: 0x0007
         doc: |
           TODO
   - name: cull_mode
@@ -359,26 +350,24 @@ enums:
     doc: |
       TODO
     entries:
+      - null
       - name: unknown
-        value: 0x0001
         doc: |
           TODO
       - name: destroyed
-        value: 0x0002
         doc: |
           TODO
       - name: instance_dropped
-        value: 0x0003
         doc: |
           TODO
       - name: failed_creation
-        value: 0x0004
         doc: |
           TODO
   - name: error_filter
     doc: |
       TODO
     entries:
+      - null
       - name: validation
         doc: |
           TODO
@@ -392,6 +381,7 @@ enums:
     doc: |
       TODO
     entries:
+      - null
       - name: no_error
         doc: |
           TODO
@@ -508,24 +498,20 @@ enums:
     doc: |
       TODO
     entries:
+      - null
       - name: success
-        value: 0x0001
         doc: |
           TODO
       - name: instance_dropped
-        value: 0x0002
         doc: |
           TODO
       - name: error
-        value: 0x0003
         doc: |
           TODO
       - name: aborted
-        value: 0x0004
         doc: |
           TODO
       - name: unknown
-        value: 0x0005
         doc: |
           TODO
   - name: mipmap_filter_mode
@@ -557,12 +543,11 @@ enums:
     doc: |
       TODO
     entries:
+      - null
       - name: success
-        value: 0x0001
         doc: |
           TODO
       - name: instance_dropped
-        value: 0x0002
         doc: |
           TODO
   - name: power_preference
@@ -626,6 +611,7 @@ enums:
     doc: |
       TODO
     entries:
+      - null
       - name: occlusion
         doc: |
           TODO
@@ -636,77 +622,64 @@ enums:
     doc: |
       TODO
     entries:
+      - null
       - name: success
-        value: 0x0001
         doc: |
           TODO
       - name: instance_dropped
-        value: 0x0002
         doc: |
           TODO
       - name: error
-        value: 0x0003
         doc: |
           TODO
       - name: unknown
-        value: 0x0004
         doc: |
           TODO
       - name: device_lost
-        value: 0x0005
         doc: |
           TODO
   - name: request_adapter_status
     doc: |
       TODO
     entries:
+      - null
       - name: success
-        value: 0x0001
         doc: |
           TODO
       - name: instance_dropped
-        value: 0x0002
         doc: |
           TODO
       - name: unavailable
-        value: 0x0003
         doc: |
           TODO
       - name: error
-        value: 0x0004
         doc: |
           TODO
       - name: unknown
-        value: 0x0005
         doc: |
           TODO
   - name: request_device_status
     doc: |
       TODO
     entries:
+      - null
       - name: success
-        value: 0x0001
         doc: |
           TODO
       - name: instance_dropped
-        value: 0x0002
         doc: |
           TODO
       - name: error
-        value: 0x0003
         doc: |
           TODO
       - name: unknown
-        value: 0x0004
         doc: |
           TODO
   - name: s_type
     doc: |
       TODO
     entries:
-      - name: invalid
-        doc: |
-          TODO
+      - null
       - name: shader_source_SPIRV
         doc: |
           TODO
@@ -761,6 +734,7 @@ enums:
       indicates an invalid input like an unknown enum value or struct chaining
       error. Read the function's documentation for specific error conditions.
     entries:
+      - null
       - name: success
         doc: ""
       - name: error
@@ -830,6 +804,7 @@ enums:
   - name: surface_get_current_texture_status
     doc: The status enum for `::wgpuSurfaceGetCurrentTexture`.
     entries:
+      - null
       - name: success_optimal
         doc: Yay! Everything is good and we can render this frame.
       - name: success_suboptimal
@@ -1219,9 +1194,7 @@ enums:
     doc: |
       TODO
     entries:
-      - name: undefined
-        doc: |
-          TODO
+      - null
       - name: uint8x2
         doc: |
           TODO
@@ -1334,6 +1307,7 @@ enums:
   - name: wait_status
     doc: Status returned from a call to ::wgpuInstanceWaitAny.
     entries:
+      - null
       - name: success
         doc: At least one WGPUFuture completed successfully.
       - name: timed_out
@@ -1348,9 +1322,7 @@ enums:
     doc: |
       TODO
     entries:
-      - name: undefined
-        doc: |
-          TODO
+      - null
       - name: readonly_and_readwrite_storage_textures
         doc: |
           TODO


### PR DESCRIPTION
**Can be reviewed as separate commits.**

- Reorder fields in VertexBufferLayout so the sentinel slot is first (even though this doesn't match the upstream IDL)
- Update `BindingNotUsed`/`VertexBufferNotUsed` enum values
- Removing some `Undefined`s that don't need to exist
- Reserved 0 in all enums without `Undefined`
- Ordered some enums to match the spec

This is a bit different from the thing we previously discussed and agreed on:

- I've swapped the values of `BindingNotUsed`=`VertexBufferNotUsed`=0 with `Undefined`=1 so that zero-init will trigger `NotUsed`. See https://github.com/webgpu-native/webgpu-headers/issues/242#issuecomment-2310857163
- I haven't introduced `WGPUTextureFormat_ColorTargetNotUsed`, opting to continue using `WGPUTextureFormat_Undefined` for this, because there's basically no chance that `WGPUColorTargetState.format` becomes optional. (Even if it did become "dynamic state" or something, I think we would use a different sentinel value than `undefined` in the JS API so that it had to be named explicitly.)

Fixes #234
Fixes #242
(done in Dawn except for the NotUsed changes; TODO file a bug for that)