### PR TITLE
Make copy command structs non-extensible

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1662,7 +1662,6 @@ typedef struct WGPUTextureBindingLayout {
 } WGPUTextureBindingLayout WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUTextureDataLayout {
-    WGPUChainedStruct const * nextInChain;
     uint64_t offset;
     uint32_t bytesPerRow;
     uint32_t rowsPerImage;
@@ -1760,13 +1759,11 @@ typedef struct WGPUFutureWaitInfo {
 } WGPUFutureWaitInfo WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUImageCopyBuffer {
-    WGPUChainedStruct const * nextInChain;
     WGPUTextureDataLayout layout;
     WGPUBuffer buffer;
 } WGPUImageCopyBuffer WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUImageCopyTexture {
-    WGPUChainedStruct const * nextInChain;
     WGPUTexture texture;
     uint32_t mipLevel;
     WGPUOrigin3D origin;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1955,7 +1955,7 @@ structs:
   - name: image_copy_buffer
     doc: |
       TODO
-    type: base_in
+    type: standalone
     members:
       - name: layout
         doc: |
@@ -1968,7 +1968,7 @@ structs:
   - name: image_copy_texture
     doc: |
       TODO
-    type: base_in
+    type: standalone
     members:
       - name: texture
         doc: |
@@ -2817,7 +2817,7 @@ structs:
   - name: texture_data_layout
     doc: |
       TODO
-    type: base_in
+    type: standalone
     members:
       - name: offset
         doc: |


### PR DESCRIPTION
These don't seem likely to be extended, and even if they were, it's not clear that the same extensions would apply to all usages of these structs. Since they have multiple usages, make them non-extensible.

These were also the only extensibility points in encoder commands, making them a bit more complex.

Fixes #224