### PR TITLE
Make WGPUSupportedFeatures non-extensible

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1659,7 +1659,6 @@ typedef struct WGPUStorageTextureBindingLayout {
 } WGPUStorageTextureBindingLayout WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUSupportedFeatures {
-    WGPUChainedStructOut * nextInChain;
     size_t featureCount;
     WGPUFeatureName const * features;
 } WGPUSupportedFeatures WGPU_STRUCTURE_ATTRIBUTE;
@@ -2149,7 +2148,7 @@ typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUStringView procName) WGPU_FUNCTIO
  * Proc pointer type for @ref wgpuAdapterGetFeatures:
  * > @copydoc wgpuAdapterGetFeatures
  */
-typedef WGPUStatus (*WGPUProcAdapterGetFeatures)(WGPUAdapter adapter, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcAdapterGetFeatures)(WGPUAdapter adapter, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuAdapterGetInfo:
  * > @copydoc wgpuAdapterGetInfo
@@ -2537,7 +2536,7 @@ typedef void (*WGPUProcDeviceDestroy)(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE
  * Proc pointer type for @ref wgpuDeviceGetFeatures:
  * > @copydoc wgpuDeviceGetFeatures
  */
-typedef WGPUStatus (*WGPUProcDeviceGetFeatures)(WGPUDevice device, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcDeviceGetFeatures)(WGPUDevice device, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuDeviceGetLimits:
  * > @copydoc wgpuDeviceGetLimits
@@ -3156,13 +3155,8 @@ WGPU_EXPORT WGPUProc wgpuGetProcAddress(WGPUStringView procName) WGPU_FUNCTION_A
  *
  * @param features
  * This parameter is @ref ReturnedWithOwnership.
- *
- * @returns
- * Return @ref WGPUStatus_Error (and leaves `features` uninitialized) if:
- *
- * - `features` has an invalid struct chain.
  */
-WGPU_EXPORT WGPUStatus wgpuAdapterGetFeatures(WGPUAdapter adapter, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuAdapterGetFeatures(WGPUAdapter adapter, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * @param info
  * This parameter is @ref ReturnedWithOwnership.
@@ -3338,13 +3332,8 @@ WGPU_EXPORT void wgpuDeviceDestroy(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
  *
  * @param features
  * This parameter is @ref ReturnedWithOwnership.
- *
- * @returns
- * Return @ref WGPUStatus_Error (and leaves `features` uninitialized) if:
- *
- * - `features` has an invalid struct chain.
  */
-WGPU_EXPORT WGPUStatus wgpuDeviceGetFeatures(WGPUDevice device, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuDeviceGetFeatures(WGPUDevice device, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBool wgpuDeviceGetLimits(WGPUDevice device, WGPULimits * limits) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUQueue wgpuDeviceGetQueue(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBool wgpuDeviceHasFeature(WGPUDevice device, WGPUFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -2644,7 +2644,7 @@ structs:
   - name: supported_features
     doc: |
       TODO
-    type: base_out
+    type: standalone
     free_members: true
     members:
       - name: features
@@ -3207,12 +3207,6 @@ objects:
       - name: get_features
         doc: |
           Get the list of @ref WGPUFeatureName values supported by the adapter.
-        returns:
-          doc: |
-            Return @ref WGPUStatus_Error (and leaves `features` uninitialized) if:
-
-            - `features` has an invalid struct chain.
-          type: enum.status
         args:
           - name: features
             doc: |
@@ -3913,12 +3907,6 @@ objects:
       - name: get_features
         doc: |
           Get the list of @ref WGPUFeatureName values supported by the device.
-        returns:
-          doc: |
-            Return @ref WGPUStatus_Error (and leaves `features` uninitialized) if:
-
-            - `features` has an invalid struct chain.
-          type: enum.status
         args:
           - name: features
             doc: |


### PR DESCRIPTION
This was the original intent: https://github.com/webgpu-native/webgpu-headers/issues/252#issuecomment-1882297333
I just did it wrong in my PR (#348).