### PR TITLE
Add WGPUPopErrorScopeStatus_EmptyStack

### DIFF
--- a/doc/articles/Strings.md
+++ b/doc/articles/Strings.md
@@ -1,6 +1,6 @@
 # Strings {#Strings}
 
-Strings are represented using the \ref WGPUStringView struct:
+Strings are represented in UTF-8, using the \ref WGPUStringView struct:
 
 > \copydoc WGPUStringView
 
@@ -18,3 +18,8 @@ If the null value is passed, it is treated as the empty string.
 This output string is always explicitly sized and never the null value. There is no null terminator inside the string; there may or may not be one after the end. If empty, the data pointer may or may not be null.
 
 To format explicitly-sized strings with `printf`, use `%.*s` (`%s` with a "precision" argument `.*` specifying the max number of bytes to read from the pointer).
+
+### Localizable Human-Readable Message String {#LocalizableHumanReadableMessageString}
+
+This is a @ref OutputString which is human-readable and implementation-dependent, and may be locale-dependent.
+It should not be parsed or otherwise treated as machine-readable.

--- a/webgpu.h
+++ b/webgpu.h
@@ -603,8 +603,17 @@ typedef enum WGPUOptionalBool {
 } WGPUOptionalBool WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUPopErrorScopeStatus {
+    /**
+     * `0x00000001`.
+     * The error scope stack was successfully popped and a result was reported.
+     */
     WGPUPopErrorScopeStatus_Success = 0x00000001,
     WGPUPopErrorScopeStatus_InstanceDropped = 0x00000002,
+    /**
+     * `0x00000003`.
+     * The error scope stack could not be popped, because it was empty.
+     */
+    WGPUPopErrorScopeStatus_EmptyStack = 0x00000003,
     WGPUPopErrorScopeStatus_Force32 = 0x7FFFFFFF
 } WGPUPopErrorScopeStatus WGPU_ENUM_ATTRIBUTE;
 
@@ -1195,7 +1204,16 @@ typedef void (*WGPUCreateRenderPipelineAsyncCallback)(WGPUCreatePipelineAsyncSta
  */
 typedef void (*WGPUDeviceLostCallback)(WGPUDevice const * device, WGPUDeviceLostReason reason, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
 /**
+ * @param status
+ * See @ref WGPUPopErrorScopeStatus.
+ *
+ * @param type
+ * The type of the error caught by the scope, or @ref WGPUErrorType_NoError if there was none.
+ * If the `status` is not @ref WGPUPopErrorScopeStatus_Success, this is @ref WGPUErrorType_NoError.
+ *
  * @param message
+ * If the `type` is not @ref WGPUErrorType_NoError, this is a non-empty @ref LocalizableHumanReadableMessageString;
+ * otherwise, this is an empty string.
  * This parameter is @ref PassedWithoutOwnership.
  */
 typedef void (*WGPUPopErrorScopeCallback)(WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -567,10 +567,13 @@ enums:
       - null
       - name: success
         doc: |
-          TODO
+          The error scope stack was successfully popped and a result was reported.
       - name: instance_dropped
         doc: |
           TODO
+      - name: empty_stack
+        doc: |
+          The error scope stack could not be popped, because it was empty.
   - name: power_preference
     doc: |
       TODO
@@ -3106,15 +3109,17 @@ callbacks:
     args:
       - name: status
         doc: |
-          TODO
+          See @ref WGPUPopErrorScopeStatus.
         type: enum.pop_error_scope_status
       - name: type
         doc: |
-          TODO
+          The type of the error caught by the scope, or @ref WGPUErrorType_NoError if there was none.
+          If the `status` is not @ref WGPUPopErrorScopeStatus_Success, this is @ref WGPUErrorType_NoError.
         type: enum.error_type
       - name: message
         doc: |
-          TODO
+          If the `type` is not @ref WGPUErrorType_NoError, this is a non-empty @ref LocalizableHumanReadableMessageString;
+          otherwise, this is an empty string.
         type: out_string
         passed_with_ownership: false
   - name: queue_work_done


### PR DESCRIPTION
And tentatively document behavior of `type`/`message` in this case.

Issue: #369 (left open for bikeshedding)