### PR TITLE
Remove DeviceLost status from WGPUSurfaceGetCurrentTextureStatus

### DIFF
--- a/doc/articles/Surfaces.md
+++ b/doc/articles/Surfaces.md
@@ -242,7 +242,7 @@ The behavior of `::wgpuSurfaceGetCurrentTexture``(surface, surfaceTexture)` is:
    - Validate that `surface.config` is not `None`.
    - Validate that `surface.currentFrame` is `None`.
 
- - If `surface.config.device` is not alive, set `surfaceTexture->status` to `WGPUSurfaceGetCurrentTextureStatus_Lost` and return.
+ - If `surface.config.device` is not alive, set `surfaceTexture->status` to `WGPUSurfaceGetCurrentTextureStatus_Success`, set `surfaceTexture->texture` to a new invalid `WGPUTexture`, and return.
  - If the implementation detects any other problem preventing use of the surface, set `surfaceTexture->status` to an appropriate status (something other than `SuccessOptimal`, `SuccessSuboptimal`, or `Error`) and return.
  - Let `textureDesc` be `GetSurfaceEquivalentTextureDescriptor(surface.config)`.
  - Create a new @ref WGPUTexture `t`, as if calling `wgpuDeviceCreateTexture(surface.config.device, &textureDesc)`, but wrapping the appropriate backing resource.

--- a/doc/articles/Surfaces.md
+++ b/doc/articles/Surfaces.md
@@ -242,8 +242,8 @@ The behavior of `::wgpuSurfaceGetCurrentTexture``(surface, surfaceTexture)` is:
    - Validate that `surface.config` is not `None`.
    - Validate that `surface.currentFrame` is `None`.
 
- - If `surface.config.device` is not alive, set `surfaceTexture->status` to `WGPUSurfaceGetCurrentTextureStatus_DeviceLost` and return.
- - If the implementation detects any other problem preventing use of the surface, set `surfaceTexture->status` to an appropriate status (something other than `SuccessOptimal`, `SuccessSuboptimal`, `Error`, or `DeviceLost`) and return.
+ - If `surface.config.device` is not alive, set `surfaceTexture->status` to `WGPUSurfaceGetCurrentTextureStatus_Lost` and return.
+ - If the implementation detects any other problem preventing use of the surface, set `surfaceTexture->status` to an appropriate status (something other than `SuccessOptimal`, `SuccessSuboptimal`, or `Error`) and return.
  - Let `textureDesc` be `GetSurfaceEquivalentTextureDescriptor(surface.config)`.
  - Create a new @ref WGPUTexture `t`, as if calling `wgpuDeviceCreateTexture(surface.config.device, &textureDesc)`, but wrapping the appropriate backing resource.
  - Set `surface.currentFrame` to `t`.

--- a/webgpu.h
+++ b/webgpu.h
@@ -820,7 +820,7 @@ typedef enum WGPUSurfaceGetCurrentTextureStatus {
     WGPUSurfaceGetCurrentTextureStatus_Outdated = 0x00000004,
     /**
      * `0x00000005`.
-     * The connection to whatever owns the surface, or the device, was lost.
+     * The device was lost, or the connection to whatever owns the surface was lost.
      */
     WGPUSurfaceGetCurrentTextureStatus_Lost = 0x00000005,
     /**

--- a/webgpu.h
+++ b/webgpu.h
@@ -820,7 +820,7 @@ typedef enum WGPUSurfaceGetCurrentTextureStatus {
     WGPUSurfaceGetCurrentTextureStatus_Outdated = 0x00000004,
     /**
      * `0x00000005`.
-     * The device was lost, or the connection to whatever owns the surface was lost.
+     * The connection to whatever owns the surface was lost.
      */
     WGPUSurfaceGetCurrentTextureStatus_Lost = 0x00000005,
     /**

--- a/webgpu.h
+++ b/webgpu.h
@@ -820,7 +820,7 @@ typedef enum WGPUSurfaceGetCurrentTextureStatus {
     WGPUSurfaceGetCurrentTextureStatus_Outdated = 0x00000004,
     /**
      * `0x00000005`.
-     * The connection to whatever owns the surface was lost.
+     * The connection to whatever owns the surface, or the device, was lost.
      */
     WGPUSurfaceGetCurrentTextureStatus_Lost = 0x00000005,
     /**
@@ -830,14 +830,9 @@ typedef enum WGPUSurfaceGetCurrentTextureStatus {
     WGPUSurfaceGetCurrentTextureStatus_OutOfMemory = 0x00000006,
     /**
      * `0x00000007`.
-     * The @ref WGPUDevice configured on the @ref WGPUSurface was lost.
-     */
-    WGPUSurfaceGetCurrentTextureStatus_DeviceLost = 0x00000007,
-    /**
-     * `0x00000008`.
      * The surface is not configured, or there was an @ref OutStructChainError.
      */
-    WGPUSurfaceGetCurrentTextureStatus_Error = 0x00000008,
+    WGPUSurfaceGetCurrentTextureStatus_Error = 0x00000007,
     WGPUSurfaceGetCurrentTextureStatus_Force32 = 0x7FFFFFFF
 } WGPUSurfaceGetCurrentTextureStatus WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -835,11 +835,9 @@ enums:
       - name: outdated
         doc: The surface is too different to be used, compared to when it was originally created.
       - name: lost
-        doc: The connection to whatever owns the surface was lost.
+        doc: The connection to whatever owns the surface, or the device, was lost.
       - name: out_of_memory
         doc: The system ran out of memory.
-      - name: device_lost
-        doc: The @ref WGPUDevice configured on the @ref WGPUSurface was lost.
       - name: error
         doc: The surface is not configured, or there was an @ref OutStructChainError.
   - name: texture_aspect

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -835,7 +835,7 @@ enums:
       - name: outdated
         doc: The surface is too different to be used, compared to when it was originally created.
       - name: lost
-        doc: The connection to whatever owns the surface, or the device, was lost.
+        doc: The device was lost, or the connection to whatever owns the surface was lost.
       - name: out_of_memory
         doc: The system ran out of memory.
       - name: error

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -835,7 +835,7 @@ enums:
       - name: outdated
         doc: The surface is too different to be used, compared to when it was originally created.
       - name: lost
-        doc: The device was lost, or the connection to whatever owns the surface was lost.
+        doc: The connection to whatever owns the surface was lost.
       - name: out_of_memory
         doc: The system ran out of memory.
       - name: error


### PR DESCRIPTION
~We didn't discuss which status we would use for this, but "Lost" seems to makes sense.~
This should behave like JS where we pretend it worked by returning a texture, but you can't use it because the device is lost.

Issue #209