### PR TITLE
Proposal: Make TimestampWrites structs extensible, move nullability inside

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1457,6 +1457,10 @@ typedef struct WGPUCompilationMessage {
 } WGPUCompilationMessage WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUComputePassTimestampWrites {
+    WGPUChainedStruct const * nextInChain;
+    /**
+     * Query set to write timestamps to. Null if timestamps should not be recorded.
+     */
     WGPUQuerySet querySet;
     uint32_t beginningOfPassWriteIndex;
     uint32_t endOfPassWriteIndex;
@@ -1629,6 +1633,10 @@ typedef struct WGPURenderPassMaxDrawCount {
 } WGPURenderPassMaxDrawCount WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassTimestampWrites {
+    WGPUChainedStruct const * nextInChain;
+    /**
+     * Query set to write timestamps to. Null if timestamps should not be recorded.
+     */
     WGPUQuerySet querySet;
     uint32_t beginningOfPassWriteIndex;
     uint32_t endOfPassWriteIndex;
@@ -1968,7 +1976,7 @@ typedef struct WGPUComputePassDescriptor {
      * This is a \ref NonNullInputString.
      */
     WGPUStringView label;
-    WGPU_NULLABLE WGPUComputePassTimestampWrites const * timestampWrites;
+    WGPUComputePassTimestampWrites timestampWrites;
 } WGPUComputePassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUDepthStencilState {
@@ -2124,7 +2132,7 @@ typedef struct WGPURenderPassDescriptor {
     WGPURenderPassColorAttachment const * colorAttachments;
     WGPU_NULLABLE WGPURenderPassDepthStencilAttachment const * depthStencilAttachment;
     WGPU_NULLABLE WGPUQuerySet occlusionQuerySet;
-    WGPU_NULLABLE WGPURenderPassTimestampWrites const * timestampWrites;
+    WGPURenderPassTimestampWrites timestampWrites;
 } WGPURenderPassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUVertexState {

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1804,16 +1804,14 @@ structs:
         doc: |
           TODO
         type: struct.compute_pass_timestamp_writes
-        pointer: immutable
-        optional: true
   - name: compute_pass_timestamp_writes
     doc: |
       TODO
-    type: standalone
+    type: base_in
     members:
       - name: query_set
         doc: |
-          TODO
+          Query set to write timestamps to. Null if timestamps should not be recorded.
         type: object.query_set
       - name: beginning_of_pass_write_index
         doc: |
@@ -2393,8 +2391,6 @@ structs:
         doc: |
           TODO
         type: struct.render_pass_timestamp_writes
-        pointer: immutable
-        optional: true
   - name: render_pass_max_draw_count
     doc: |
       TODO
@@ -2409,11 +2405,11 @@ structs:
   - name: render_pass_timestamp_writes
     doc: |
       TODO
-    type: standalone
+    type: base_in
     members:
       - name: query_set
         doc: |
-          TODO
+          Query set to write timestamps to. Null if timestamps should not be recorded.
         type: object.query_set
       - name: beginning_of_pass_write_index
         doc: |


### PR DESCRIPTION
Issue: None, I think @Kangz found this while we were reviewing the header.