### PR TITLE
Make WGPURenderPassDepthStencilAttachment extensible

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1630,6 +1630,7 @@ typedef struct WGPURenderBundleEncoderDescriptor {
 } WGPURenderBundleEncoderDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassDepthStencilAttachment {
+    WGPUChainedStruct const * nextInChain;
     WGPUTextureView view;
     WGPULoadOp depthLoadOp;
     WGPUStoreOp depthStoreOp;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -2337,7 +2337,7 @@ structs:
   - name: render_pass_depth_stencil_attachment
     doc: |
       TODO
-    type: standalone
+    type: base_in
     members:
       - name: view
         doc: |


### PR DESCRIPTION
WGPURenderPassColorAttachment is already extensible, this should be too.

Issue: None, I think @Kangz found this while we were reviewing the header.
(dawn bug https://crbug.com/378514256)