### PR TITLE
Proposal: Rename WGPUProgrammableStageDescriptor -> WGPUComputeStage

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -226,11 +226,11 @@ struct WGPUBindGroupLayoutEntry;
 struct WGPUBlendState;
 struct WGPUCompilationInfo;
 struct WGPUComputePassDescriptor;
+struct WGPUComputeStage;
 struct WGPUDepthStencilState;
 struct WGPUDeviceDescriptor;
 struct WGPUFutureWaitInfo;
 struct WGPUInstanceDescriptor;
-struct WGPUProgrammableStageDescriptor;
 struct WGPURenderPassColorAttachment;
 struct WGPUTexelCopyBufferInfo;
 struct WGPUTexelCopyTextureInfo;
@@ -2026,6 +2026,17 @@ typedef struct WGPUComputePassDescriptor {
     WGPUComputePassTimestampWrites timestampWrites;
 } WGPUComputePassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
+typedef struct WGPUComputeStage {
+    WGPUChainedStruct const * nextInChain;
+    WGPUShaderModule module;
+    /**
+     * This is a \ref NullableInputString.
+     */
+    WGPUStringView entryPoint;
+    size_t constantCount;
+    WGPUConstantEntry const * constants;
+} WGPUComputeStage WGPU_STRUCTURE_ATTRIBUTE;
+
 typedef struct WGPUDepthStencilState {
     WGPUChainedStruct const * nextInChain;
     WGPUTextureFormat format;
@@ -2075,17 +2086,6 @@ typedef struct WGPUInstanceDescriptor {
      */
     WGPUInstanceCapabilities features;
 } WGPUInstanceDescriptor WGPU_STRUCTURE_ATTRIBUTE;
-
-typedef struct WGPUProgrammableStageDescriptor {
-    WGPUChainedStruct const * nextInChain;
-    WGPUShaderModule module;
-    /**
-     * This is a \ref NullableInputString.
-     */
-    WGPUStringView entryPoint;
-    size_t constantCount;
-    WGPUConstantEntry const * constants;
-} WGPUProgrammableStageDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassColorAttachment {
     WGPUChainedStruct const * nextInChain;
@@ -2167,7 +2167,7 @@ typedef struct WGPUComputePipelineDescriptor {
      */
     WGPUStringView label;
     WGPU_NULLABLE WGPUPipelineLayout layout;
-    WGPUProgrammableStageDescriptor compute;
+    WGPUComputeStage compute;
 } WGPUComputePipelineDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassDescriptor {

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1849,7 +1849,25 @@ structs:
       - name: compute
         doc: |
           TODO
-        type: struct.programmable_stage_descriptor
+        type: struct.compute_stage
+  - name: compute_stage
+    doc: |
+      TODO
+    type: base_in
+    members:
+      - name: module
+        doc: |
+          TODO
+        type: object.shader_module
+      - name: entry_point
+        doc: |
+          TODO
+        type: nullable_string
+      - name: constants
+        doc: |
+          TODO
+        type: array<struct.constant_entry>
+        pointer: immutable
   - name: constant_entry
     doc: |
       TODO
@@ -2218,24 +2236,6 @@ structs:
         doc: |
           TODO
         type: bool
-  - name: programmable_stage_descriptor
-    doc: |
-      TODO
-    type: base_in
-    members:
-      - name: module
-        doc: |
-          TODO
-        type: object.shader_module
-      - name: entry_point
-        doc: |
-          TODO
-        type: nullable_string
-      - name: constants
-        doc: |
-          TODO
-        type: array<struct.constant_entry>
-        pointer: immutable
   - name: query_set_descriptor
     doc: |
       TODO


### PR DESCRIPTION
In JS, `WGPUProgrammableStage` (no `Descriptor`, it was renamed) is the base dictionary for vertex/fragment/compute. But in C we don't use it for that, we only use it for compute because compute doesn't add any other members. So we should name it accordingly. Since the JS type is `WGPUProgrammableStage`, I've called it `WGPUComputeStage`.

Both `WGPUComputePipelineDescriptor` and `WGPUComputeStage` are still both extensible, which makes reasonable sense and matches `WGPURenderPipelineDescriptor`/`WGPUVertexState`/`WGPUFragmentState`.

(Note naming: `State` vs `Stage`. This could be `WGPUComputeState` but that didn't make as much sense to me. Not sure if it's better for it to match.)

Fixes #409