### PR TITLE
Remove all "Unknown" async statuses

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -419,7 +419,6 @@ typedef enum WGPUCompilationInfoRequestStatus {
     WGPUCompilationInfoRequestStatus_Success = 0x00000001,
     WGPUCompilationInfoRequestStatus_InstanceDropped = 0x00000002,
     WGPUCompilationInfoRequestStatus_Error = 0x00000003,
-    WGPUCompilationInfoRequestStatus_Unknown = 0x00000004,
     WGPUCompilationInfoRequestStatus_Force32 = 0x7FFFFFFF
 } WGPUCompilationInfoRequestStatus WGPU_ENUM_ATTRIBUTE;
 
@@ -467,7 +466,6 @@ typedef enum WGPUCreatePipelineAsyncStatus {
     WGPUCreatePipelineAsyncStatus_InstanceDropped = 0x00000002,
     WGPUCreatePipelineAsyncStatus_ValidationError = 0x00000003,
     WGPUCreatePipelineAsyncStatus_InternalError = 0x00000004,
-    WGPUCreatePipelineAsyncStatus_Unknown = 0x00000005,
     WGPUCreatePipelineAsyncStatus_Force32 = 0x7FFFFFFF
 } WGPUCreatePipelineAsyncStatus WGPU_ENUM_ATTRIBUTE;
 
@@ -594,7 +592,6 @@ typedef enum WGPUMapAsyncStatus {
     WGPUMapAsyncStatus_InstanceDropped = 0x00000002,
     WGPUMapAsyncStatus_Error = 0x00000003,
     WGPUMapAsyncStatus_Aborted = 0x00000004,
-    WGPUMapAsyncStatus_Unknown = 0x00000005,
     WGPUMapAsyncStatus_Force32 = 0x7FFFFFFF
 } WGPUMapAsyncStatus WGPU_ENUM_ATTRIBUTE;
 
@@ -704,7 +701,6 @@ typedef enum WGPUQueueWorkDoneStatus {
     WGPUQueueWorkDoneStatus_Success = 0x00000001,
     WGPUQueueWorkDoneStatus_InstanceDropped = 0x00000002,
     WGPUQueueWorkDoneStatus_Error = 0x00000003,
-    WGPUQueueWorkDoneStatus_Unknown = 0x00000004,
     WGPUQueueWorkDoneStatus_Force32 = 0x7FFFFFFF
 } WGPUQueueWorkDoneStatus WGPU_ENUM_ATTRIBUTE;
 
@@ -713,7 +709,6 @@ typedef enum WGPURequestAdapterStatus {
     WGPURequestAdapterStatus_InstanceDropped = 0x00000002,
     WGPURequestAdapterStatus_Unavailable = 0x00000003,
     WGPURequestAdapterStatus_Error = 0x00000004,
-    WGPURequestAdapterStatus_Unknown = 0x00000005,
     WGPURequestAdapterStatus_Force32 = 0x7FFFFFFF
 } WGPURequestAdapterStatus WGPU_ENUM_ATTRIBUTE;
 
@@ -721,7 +716,6 @@ typedef enum WGPURequestDeviceStatus {
     WGPURequestDeviceStatus_Success = 0x00000001,
     WGPURequestDeviceStatus_InstanceDropped = 0x00000002,
     WGPURequestDeviceStatus_Error = 0x00000003,
-    WGPURequestDeviceStatus_Unknown = 0x00000004,
     WGPURequestDeviceStatus_Force32 = 0x7FFFFFFF
 } WGPURequestDeviceStatus WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -284,9 +284,6 @@ enums:
       - name: error
         doc: |
           TODO
-      - name: unknown
-        doc: |
-          TODO
   - name: compilation_message_type
     doc: |
       TODO
@@ -329,9 +326,6 @@ enums:
         doc: |
           TODO
       - name: internal_error
-        doc: |
-          TODO
-      - name: unknown
         doc: |
           TODO
   - name: cull_mode
@@ -531,9 +525,6 @@ enums:
       - name: aborted
         doc: |
           TODO
-      - name: unknown
-        doc: |
-          TODO
   - name: mipmap_filter_mode
     doc: |
       TODO
@@ -655,9 +646,6 @@ enums:
       - name: error
         doc: |
           TODO
-      - name: unknown
-        doc: |
-          TODO
   - name: request_adapter_status
     doc: |
       TODO
@@ -675,9 +663,6 @@ enums:
       - name: error
         doc: |
           TODO
-      - name: unknown
-        doc: |
-          TODO
   - name: request_device_status
     doc: |
       TODO
@@ -690,9 +675,6 @@ enums:
         doc: |
           TODO
       - name: error
-        doc: |
-          TODO
-      - name: unknown
         doc: |
           TODO
   - name: s_type


### PR DESCRIPTION
These were used by Dawn to indicate wire connection errors, but those should either be Success/Unavailable or InstanceDropped (TBD which).

Issue #401