### PR TITLE
Add surface color management to header in block 0x0001

### DIFF
--- a/gen/yml.go
+++ b/gen/yml.go
@@ -10,7 +10,7 @@ import (
 type Yml struct {
 	Copyright  string `yaml:"copyright"`
 	Name       string `yaml:"name"`
-	EnumPrefix string `yaml:"enum_prefix"`
+	EnumPrefix uint16 `yaml:"enum_prefix"`
 
 	Constants []Constant `yaml:"constants"`
 	Typedefs  []Typedef  `yaml:"typedefs"`
@@ -41,9 +41,10 @@ type Enum struct {
 	Extended bool         `yaml:"extended"`
 }
 type EnumEntry struct {
-	Name  string `yaml:"name"`
-	Doc   string `yaml:"doc"`
-	Value string `yaml:"value"`
+	Name  string  `yaml:"name"`
+	Doc   string  `yaml:"doc"`
+	Block *uint16 `yaml:"block"`
+	Value *uint16 `yaml:"value"`
 }
 
 type Bitflag struct {

--- a/schema.json
+++ b/schema.json
@@ -241,8 +241,7 @@
             "description": "The name/namespace of the specification"
         },
         "enum_prefix": {
-            "type": "string",
-            "pattern": "^0x[0-9]{4}$",
+            "$ref": "#/definitions/Value16",
             "description": "The dedicated enum prefix for the implementation specific header to avoid collisions"
         },
         "typedefs": {
@@ -328,11 +327,37 @@
                                         },
                                         "value": {
                                             "$ref": "#/definitions/Value16",
-                                            "description": "Optional property, a 16-bit unsigned integer"
+                                            "description": "Optional override for the value of the enum entry, a 16-bit unsigned integer"
                                         }
                                     },
                                     "required": [
                                         "name",
+                                        "doc"
+                                    ]
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "$ref": "#/definitions/Name",
+                                            "description": "Name of the enum entry"
+                                        },
+                                        "doc": {
+                                            "type": "string"
+                                        },
+                                        "block": {
+                                            "$ref": "#/definitions/Value16",
+                                            "description": "Block for the enum entry, a 16-bit unsigned integer"
+                                        },
+                                        "value": {
+                                            "$ref": "#/definitions/Value16",
+                                            "description": "Value for the enum entry, a 16-bit unsigned integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "name",
+                                        "block",
+                                        "value",
                                         "doc"
                                     ]
                                 }

--- a/webgpu.h
+++ b/webgpu.h
@@ -733,16 +733,16 @@ typedef enum WGPURequestDeviceStatus {
 } WGPURequestDeviceStatus WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUSType {
-    WGPUSType_ShaderSourceSPIRV = 0x00000001,
-    WGPUSType_ShaderSourceWGSL = 0x00000002,
-    WGPUSType_RenderPassMaxDrawCount = 0x00000003,
-    WGPUSType_SurfaceSourceMetalLayer = 0x00000004,
-    WGPUSType_SurfaceSourceWindowsHWND = 0x00000005,
-    WGPUSType_SurfaceSourceXlibWindow = 0x00000006,
-    WGPUSType_SurfaceSourceWaylandSurface = 0x00000007,
-    WGPUSType_SurfaceSourceAndroidNativeWindow = 0x00000008,
-    WGPUSType_SurfaceSourceXCBWindow = 0x00000009,
-    WGPUSType_SurfaceColorManagement = 0x00010000,
+    WGPUSType_ShaderSourceWGSL = 0x00000001,
+    WGPUSType_RenderPassMaxDrawCount = 0x00000002,
+    WGPUSType_ShaderSourceSPIRV = 0x00010000,
+    WGPUSType_SurfaceSourceMetalLayer = 0x00010001,
+    WGPUSType_SurfaceSourceWindowsHWND = 0x00010002,
+    WGPUSType_SurfaceSourceXlibWindow = 0x00010003,
+    WGPUSType_SurfaceSourceWaylandSurface = 0x00010004,
+    WGPUSType_SurfaceSourceAndroidNativeWindow = 0x00010006,
+    WGPUSType_SurfaceSourceXCBWindow = 0x00010007,
+    WGPUSType_SurfaceColorManagement = 0x00010008,
     WGPUSType_Force32 = 0x7FFFFFFF
 } WGPUSType WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.h
+++ b/webgpu.h
@@ -208,6 +208,7 @@ struct WGPUStorageTextureBindingLayout;
 struct WGPUSupportedFeatures;
 struct WGPUSupportedWGSLLanguageFeatures;
 struct WGPUSurfaceCapabilities;
+struct WGPUSurfaceColorManagement;
 struct WGPUSurfaceConfiguration;
 struct WGPUSurfaceDescriptor;
 struct WGPUSurfaceSourceAndroidNativeWindow;
@@ -642,6 +643,12 @@ typedef enum WGPUPowerPreference {
     WGPUPowerPreference_Force32 = 0x7FFFFFFF
 } WGPUPowerPreference WGPU_ENUM_ATTRIBUTE;
 
+typedef enum WGPUPredefinedColorSpace {
+    WGPUPredefinedColorSpace_SRGB = 0x00010001,
+    WGPUPredefinedColorSpace_DisplayP3 = 0x00010002,
+    WGPUPredefinedColorSpace_Force32 = 0x7FFFFFFF
+} WGPUPredefinedColorSpace WGPU_ENUM_ATTRIBUTE;
+
 /**
  * Describes when and in which order frames are presented on the screen when `::wgpuSurfacePresent` is called.
  */
@@ -735,6 +742,7 @@ typedef enum WGPUSType {
     WGPUSType_SurfaceSourceWaylandSurface = 0x00000007,
     WGPUSType_SurfaceSourceAndroidNativeWindow = 0x00000008,
     WGPUSType_SurfaceSourceXCBWindow = 0x00000009,
+    WGPUSType_SurfaceColorManagement = 0x00010000,
     WGPUSType_Force32 = 0x7FFFFFFF
 } WGPUSType WGPU_ENUM_ATTRIBUTE;
 
@@ -1025,6 +1033,12 @@ typedef enum WGPUTextureViewDimension {
     WGPUTextureViewDimension_3D = 0x00000006,
     WGPUTextureViewDimension_Force32 = 0x7FFFFFFF
 } WGPUTextureViewDimension WGPU_ENUM_ATTRIBUTE;
+
+typedef enum WGPUToneMappingMode {
+    WGPUToneMappingMode_Standard = 0x00010001,
+    WGPUToneMappingMode_Extended = 0x00010002,
+    WGPUToneMappingMode_Force32 = 0x7FFFFFFF
+} WGPUToneMappingMode WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUVertexFormat {
     WGPUVertexFormat_Uint8 = 0x00000001,
@@ -1792,6 +1806,15 @@ typedef struct WGPUSurfaceCapabilities {
     size_t alphaModeCount;
     WGPUCompositeAlphaMode const * alphaModes;
 } WGPUSurfaceCapabilities WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Extension of @ref WGPUSurfaceConfiguration for color spaces and HDR.
+ */
+typedef struct WGPUSurfaceColorManagement {
+    WGPUChainedStruct chain;
+    WGPUPredefinedColorSpace colorSpace;
+    WGPUToneMappingMode toneMappingMode;
+} WGPUSurfaceColorManagement WGPU_STRUCTURE_ATTRIBUTE;
 
 /**
  * Options to `::wgpuSurfaceConfigure` for defining how a @ref WGPUSurface will be rendered to and presented to the user.

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -3,7 +3,7 @@ copyright: |
 
   SPDX-License-Identifier: BSD-3-Clause
 name: webgpu
-enum_prefix: '0x0000'
+enum_prefix: 0x0000
 constants:
   - name: array_layer_count_undefined
     value: uint32_max
@@ -585,6 +585,21 @@ enums:
       - name: high_performance
         doc: |
           TODO
+  - name: predefined_color_space
+    doc: |
+      TODO
+    entries:
+      - null
+      - name: SRGB
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0001
+      - name: display_p3
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0002
   - name: present_mode
     doc: Describes when and in which order frames are presented on the screen when `::wgpuSurfacePresent` is called.
     entries:
@@ -728,6 +743,11 @@ enums:
       - name: surface_source_XCB_window
         doc: |
           TODO
+      - name: surface_color_management
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0000
   - name: sampler_binding_type
     doc: |
       TODO
@@ -1212,6 +1232,21 @@ enums:
       - name: 3D
         doc: |
           TODO
+  - name: tone_mapping_mode
+    doc: |
+      TODO
+    entries:
+      - null
+      - name: standard
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0001
+      - name: extended
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0002
   - name: vertex_format
     doc: |
       TODO
@@ -2679,6 +2714,17 @@ structs:
           @ref WGPUCompositeAlphaMode_Auto will be an alias for the first element and will never be present in this array.
         type: array<enum.composite_alpha_mode>
         pointer: immutable
+  - name: surface_color_management
+    doc: |
+      Extension of @ref WGPUSurfaceConfiguration for color spaces and HDR.
+    type: extension_in
+    members:
+      - name: color_space
+        doc: TODO
+        type: enum.predefined_color_space
+      - name: tone_mapping_mode
+        doc: TODO
+        type: enum.tone_mapping_mode
   - name: surface_configuration
     doc: |
       Options to `::wgpuSurfaceConfigure` for defining how a @ref WGPUSurface will be rendered to and presented to the user.

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -715,39 +715,52 @@ enums:
       TODO
     entries:
       - null
-      - name: shader_source_SPIRV
-        doc: |
-          TODO
       - name: shader_source_WGSL
         doc: |
           TODO
       - name: render_pass_max_draw_count
         doc: |
           TODO
-      # TODO(#214): Move all of the surface sources into block 0x0001
-      - name: surface_source_metal_layer
-        doc: |
-          TODO
-      - name: surface_source_windows_HWND
-        doc: |
-          TODO
-      - name: surface_source_xlib_window
-        doc: |
-          TODO
-      - name: surface_source_wayland_surface
-        doc: |
-          TODO
-      - name: surface_source_android_native_window
-        doc: |
-          TODO
-      - name: surface_source_XCB_window
-        doc: |
-          TODO
-      - name: surface_color_management
+      - name: shader_source_SPIRV
         doc: |
           TODO
         block: 0x0001
         value: 0x0000
+      - name: surface_source_metal_layer
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0001
+      - name: surface_source_windows_HWND
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0002
+      - name: surface_source_xlib_window
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0003
+      - name: surface_source_wayland_surface
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0004
+      - name: surface_source_android_native_window
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0006
+      - name: surface_source_XCB_window
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0007
+      - name: surface_color_management
+        doc: |
+          TODO
+        block: 0x0001
+        value: 0x0008
   - name: sampler_binding_type
     doc: |
       TODO


### PR DESCRIPTION
Modifies the generator to allow mixing block 0x0001 into the main file, and fixes the TODO about moving surface sources into block 1.

I also moved ShaderSourceSPIRV into block 1 because I'm pretty sure that's where we intended to put it.

Should the new enums really use block 0x0001? Seems like if we ever put this stuff in "core" they could use the same enums, would we then duplicate them into block 0x0000 or just use the block 0x0001 values? Or should we just put them in block 0x0000 to start?

Issue #200