### PR TITLE
Make WGPUProcDeviceGetAdapterInfo return WGPUStatus

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -2640,7 +2640,7 @@ typedef void (*WGPUProcDeviceDestroy)(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE
  * Proc pointer type for @ref wgpuDeviceGetAdapterInfo:
  * > @copydoc wgpuDeviceGetAdapterInfo
  */
-typedef WGPUAdapterInfo (*WGPUProcDeviceGetAdapterInfo)(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
+typedef WGPUStatus (*WGPUProcDeviceGetAdapterInfo)(WGPUDevice device, WGPUAdapterInfo * adapterInfo) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuDeviceGetFeatures:
  * > @copydoc wgpuDeviceGetFeatures
@@ -3493,7 +3493,14 @@ WGPU_EXPORT WGPUSampler wgpuDeviceCreateSampler(WGPUDevice device, WGPU_NULLABLE
 WGPU_EXPORT WGPUShaderModule wgpuDeviceCreateShaderModule(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUTexture wgpuDeviceCreateTexture(WGPUDevice device, WGPUTextureDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuDeviceDestroy(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT WGPUAdapterInfo wgpuDeviceGetAdapterInfo(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @param adapterInfo
+ * This parameter is @ref ReturnedWithOwnership.
+ *
+ * @returns
+ * Indicates if there was an @ref OutStructChainError.
+ */
+WGPU_EXPORT WGPUStatus wgpuDeviceGetAdapterInfo(WGPUDevice device, WGPUAdapterInfo * adapterInfo) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Get the list of @ref WGPUFeatureName values supported by the device.
  *

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -3975,10 +3975,15 @@ objects:
         doc: |
           TODO
         returns:
-          doc: |
-            TODO
-          type: struct.adapter_info
-          passed_with_ownership: true
+          doc: Indicates if there was an @ref OutStructChainError.
+          type: enum.status
+        args:
+          - name: adapter_info
+            doc: |
+              TODO
+            type: struct.adapter_info
+            pointer: mutable
+            passed_with_ownership: true
       - name: get_queue
         doc: |
           TODO


### PR DESCRIPTION
Following https://github.com/webgpu-native/webgpu-headers/pull/377 changes (specifically those in WGPUProcAdapterGetInfo), this PR makes WGPUProcDeviceGetAdapterInfo return WGPUStatus.