### PR TITLE
Add surface color management extension

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -208,6 +208,7 @@ struct WGPUStorageTextureBindingLayout;
 struct WGPUSupportedFeatures;
 struct WGPUSupportedWGSLLanguageFeatures;
 struct WGPUSurfaceCapabilities;
+struct WGPUSurfaceColorManagement;
 struct WGPUSurfaceConfiguration;
 struct WGPUSurfaceDescriptor;
 struct WGPUSurfaceSourceAndroidNativeWindow;
@@ -642,6 +643,12 @@ typedef enum WGPUPowerPreference {
     WGPUPowerPreference_Force32 = 0x7FFFFFFF
 } WGPUPowerPreference WGPU_ENUM_ATTRIBUTE;
 
+typedef enum WGPUPredefinedColorSpace {
+    WGPUPredefinedColorSpace_SRGB = 0x00000001,
+    WGPUPredefinedColorSpace_DisplayP3 = 0x00000002,
+    WGPUPredefinedColorSpace_Force32 = 0x7FFFFFFF
+} WGPUPredefinedColorSpace WGPU_ENUM_ATTRIBUTE;
+
 /**
  * Describes when and in which order frames are presented on the screen when `::wgpuSurfacePresent` is called.
  */
@@ -735,6 +742,7 @@ typedef enum WGPUSType {
     WGPUSType_SurfaceSourceWaylandSurface = 0x00000007,
     WGPUSType_SurfaceSourceAndroidNativeWindow = 0x00000008,
     WGPUSType_SurfaceSourceXCBWindow = 0x00000009,
+    WGPUSType_SurfaceColorManagement = 0x0000000A,
     WGPUSType_Force32 = 0x7FFFFFFF
 } WGPUSType WGPU_ENUM_ATTRIBUTE;
 
@@ -1020,6 +1028,12 @@ typedef enum WGPUTextureViewDimension {
     WGPUTextureViewDimension_3D = 0x00000006,
     WGPUTextureViewDimension_Force32 = 0x7FFFFFFF
 } WGPUTextureViewDimension WGPU_ENUM_ATTRIBUTE;
+
+typedef enum WGPUToneMappingMode {
+    WGPUToneMappingMode_Standard = 0x00000001,
+    WGPUToneMappingMode_Extended = 0x00000002,
+    WGPUToneMappingMode_Force32 = 0x7FFFFFFF
+} WGPUToneMappingMode WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUVertexFormat {
     WGPUVertexFormat_Uint8 = 0x00000001,
@@ -1809,6 +1823,15 @@ typedef struct WGPUSurfaceCapabilities {
     size_t alphaModeCount;
     WGPUCompositeAlphaMode const * alphaModes;
 } WGPUSurfaceCapabilities WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Extension of @ref WGPUSurfaceConfiguration for color spaces and HDR.
+ */
+typedef struct WGPUSurfaceColorManagement {
+    WGPUChainedStruct chain;
+    WGPUPredefinedColorSpace colorSpace;
+    WGPUToneMappingMode toneMappingMode;
+} WGPUSurfaceColorManagement WGPU_STRUCTURE_ATTRIBUTE;
 
 /**
  * Options to `::wgpuSurfaceConfigure` for defining how a @ref WGPUSurface will be rendered to and presented to the user.

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -585,6 +585,17 @@ enums:
       - name: high_performance
         doc: |
           TODO
+  - name: predefined_color_space
+    doc: |
+      TODO
+    entries:
+      - null
+      - name: SRGB
+        doc: |
+          TODO
+      - name: display_p3
+        doc: |
+          TODO
   - name: present_mode
     doc: Describes when and in which order frames are presented on the screen when `::wgpuSurfacePresent` is called.
     entries:
@@ -726,6 +737,9 @@ enums:
         doc: |
           TODO
       - name: surface_source_XCB_window
+        doc: |
+          TODO
+      - name: surface_color_management
         doc: |
           TODO
   - name: sampler_binding_type
@@ -1208,6 +1222,17 @@ enums:
         doc: |
           TODO
       - name: 3D
+        doc: |
+          TODO
+  - name: tone_mapping_mode
+    doc: |
+      TODO
+    entries:
+      - null
+      - name: standard
+        doc: |
+          TODO
+      - name: extended
         doc: |
           TODO
   - name: vertex_format
@@ -2677,6 +2702,17 @@ structs:
           @ref WGPUCompositeAlphaMode_Auto will be an alias for the first element and will never be present in this array.
         type: array<enum.composite_alpha_mode>
         pointer: immutable
+  - name: surface_color_management
+    doc: |
+      Extension of @ref WGPUSurfaceConfiguration for color spaces and HDR.
+    type: extension_in
+    members:
+      - name: color_space
+        doc: TODO
+        type: enum.predefined_color_space
+      - name: tone_mapping_mode
+        doc: TODO
+        type: enum.tone_mapping_mode
   - name: surface_configuration
     doc: |
       Options to `::wgpuSurfaceConfigure` for defining how a @ref WGPUSurface will be rendered to and presented to the user.


### PR DESCRIPTION
For now in block 0x0000; issue #420 tracks fixing that (superseding #417).

Other than that, fixes #200 assuming we decide this is the way to go. (It is still labeled `!discuss` to figure that out.)