### PR TITLE
Deduplicate TimestampWrites structs

### DIFF
--- a/tests/compile/main.inl
+++ b/tests/compile/main.inl
@@ -33,7 +33,7 @@ int main(void) {
         uint64_t y = a.maxBufferSize = WGPU_LIMIT_U64_UNDEFINED;
     }
     {
-        WGPUComputePassTimestampWrites a;
+        WGPUPassTimestampWrites a;
         a.beginningOfPassWriteIndex = WGPU_QUERY_SET_INDEX_UNDEFINED;
         a.endOfPassWriteIndex = WGPU_QUERY_SET_INDEX_UNDEFINED;
     }
@@ -59,12 +59,12 @@ int main(void) {
     { WGPUCommandBufferDescriptor x = WGPU_COMMAND_BUFFER_DESCRIPTOR_INIT; }
     { WGPUCommandEncoderDescriptor x = WGPU_COMMAND_ENCODER_DESCRIPTOR_INIT; }
     { WGPUCompilationMessage x = WGPU_COMPILATION_MESSAGE_INIT; }
-    { WGPUComputePassTimestampWrites x = WGPU_COMPUTE_PASS_TIMESTAMP_WRITES_INIT; }
     { WGPUConstantEntry x = WGPU_CONSTANT_ENTRY_INIT; }
     { WGPUFuture x = WGPU_FUTURE_INIT; }
     { WGPUInstanceCapabilities x = WGPU_INSTANCE_CAPABILITIES_INIT; }
     { WGPULimits x = WGPU_LIMITS_INIT; }
     { WGPUMultisampleState x = WGPU_MULTISAMPLE_STATE_INIT; }
+    { WGPUPassTimestampWrites x = WGPU_PASS_TIMESTAMP_WRITES_INIT; }
     { WGPUPipelineLayoutDescriptor x = WGPU_PIPELINE_LAYOUT_DESCRIPTOR_INIT; }
     { WGPUPrimitiveState x = WGPU_PRIMITIVE_STATE_INIT; }
     { WGPUQuerySetDescriptor x = WGPU_QUERY_SET_DESCRIPTOR_INIT; }
@@ -73,7 +73,6 @@ int main(void) {
     { WGPURenderBundleEncoderDescriptor x = WGPU_RENDER_BUNDLE_ENCODER_DESCRIPTOR_INIT; }
     { WGPURenderPassDepthStencilAttachment x = WGPU_RENDER_PASS_DEPTH_STENCIL_ATTACHMENT_INIT; }
     { WGPURenderPassMaxDrawCount x = WGPU_RENDER_PASS_MAX_DRAW_COUNT_INIT; }
-    { WGPURenderPassTimestampWrites x = WGPU_RENDER_PASS_TIMESTAMP_WRITES_INIT; }
     { WGPURequestAdapterOptions x = WGPU_REQUEST_ADAPTER_OPTIONS_INIT; }
     { WGPUSamplerBindingLayout x = WGPU_SAMPLER_BINDING_LAYOUT_INIT; }
     { WGPUSamplerDescriptor x = WGPU_SAMPLER_DESCRIPTOR_INIT; }

--- a/webgpu.h
+++ b/webgpu.h
@@ -193,7 +193,6 @@ struct WGPUColor;
 struct WGPUCommandBufferDescriptor;
 struct WGPUCommandEncoderDescriptor;
 struct WGPUCompilationMessage;
-struct WGPUComputePassTimestampWrites;
 struct WGPUConstantEntry;
 struct WGPUExtent3D;
 struct WGPUFuture;
@@ -201,6 +200,7 @@ struct WGPUInstanceCapabilities;
 struct WGPULimits;
 struct WGPUMultisampleState;
 struct WGPUOrigin3D;
+struct WGPUPassTimestampWrites;
 struct WGPUPipelineLayoutDescriptor;
 struct WGPUPrimitiveState;
 struct WGPUQuerySetDescriptor;
@@ -209,7 +209,6 @@ struct WGPURenderBundleDescriptor;
 struct WGPURenderBundleEncoderDescriptor;
 struct WGPURenderPassDepthStencilAttachment;
 struct WGPURenderPassMaxDrawCount;
-struct WGPURenderPassTimestampWrites;
 struct WGPURequestAdapterOptions;
 struct WGPUSamplerBindingLayout;
 struct WGPUSamplerDescriptor;
@@ -1860,37 +1859,6 @@ typedef struct WGPUCompilationMessage {
 })
 
 /**
- * Default values can be set using @ref WGPU_COMPUTE_PASS_TIMESTAMP_WRITES_INIT as initializer.
- */
-typedef struct WGPUComputePassTimestampWrites {
-    WGPUChainedStruct const * nextInChain;
-    /**
-     * Query set to write timestamps to.
-     *
-     * The `INIT` macro sets this to `NULL`.
-     */
-    WGPUQuerySet querySet;
-    /**
-     * The `INIT` macro sets this to @ref WGPU_QUERY_SET_INDEX_UNDEFINED.
-     */
-    uint32_t beginningOfPassWriteIndex;
-    /**
-     * The `INIT` macro sets this to @ref WGPU_QUERY_SET_INDEX_UNDEFINED.
-     */
-    uint32_t endOfPassWriteIndex;
-} WGPUComputePassTimestampWrites WGPU_STRUCTURE_ATTRIBUTE;
-
-/**
- * Initializer for @ref WGPUComputePassTimestampWrites.
- */
-#define WGPU_COMPUTE_PASS_TIMESTAMP_WRITES_INIT _wgpu_MAKE_INIT_STRUCT(WGPUComputePassTimestampWrites, { \
-    /*.nextInChain=*/NULL _wgpu_COMMA \
-    /*.querySet=*/NULL _wgpu_COMMA \
-    /*.beginningOfPassWriteIndex=*/WGPU_QUERY_SET_INDEX_UNDEFINED _wgpu_COMMA \
-    /*.endOfPassWriteIndex=*/WGPU_QUERY_SET_INDEX_UNDEFINED _wgpu_COMMA \
-})
-
-/**
  * Default values can be set using @ref WGPU_CONSTANT_ENTRY_INIT as initializer.
  */
 typedef struct WGPUConstantEntry {
@@ -2222,6 +2190,37 @@ typedef struct WGPUOrigin3D {
 })
 
 /**
+ * Default values can be set using @ref WGPU_PASS_TIMESTAMP_WRITES_INIT as initializer.
+ */
+typedef struct WGPUPassTimestampWrites {
+    WGPUChainedStruct const * nextInChain;
+    /**
+     * Query set to write timestamps to.
+     *
+     * The `INIT` macro sets this to `NULL`.
+     */
+    WGPUQuerySet querySet;
+    /**
+     * The `INIT` macro sets this to @ref WGPU_QUERY_SET_INDEX_UNDEFINED.
+     */
+    uint32_t beginningOfPassWriteIndex;
+    /**
+     * The `INIT` macro sets this to @ref WGPU_QUERY_SET_INDEX_UNDEFINED.
+     */
+    uint32_t endOfPassWriteIndex;
+} WGPUPassTimestampWrites WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Initializer for @ref WGPUPassTimestampWrites.
+ */
+#define WGPU_PASS_TIMESTAMP_WRITES_INIT _wgpu_MAKE_INIT_STRUCT(WGPUPassTimestampWrites, { \
+    /*.nextInChain=*/NULL _wgpu_COMMA \
+    /*.querySet=*/NULL _wgpu_COMMA \
+    /*.beginningOfPassWriteIndex=*/WGPU_QUERY_SET_INDEX_UNDEFINED _wgpu_COMMA \
+    /*.endOfPassWriteIndex=*/WGPU_QUERY_SET_INDEX_UNDEFINED _wgpu_COMMA \
+})
+
+/**
  * Default values can be set using @ref WGPU_PIPELINE_LAYOUT_DESCRIPTOR_INIT as initializer.
  */
 typedef struct WGPUPipelineLayoutDescriptor {
@@ -2488,37 +2487,6 @@ typedef struct WGPURenderPassMaxDrawCount {
         /*.sType=*/WGPUSType_RenderPassMaxDrawCount _wgpu_COMMA \
     }) _wgpu_COMMA \
     /*.maxDrawCount=*/50000000 _wgpu_COMMA \
-})
-
-/**
- * Default values can be set using @ref WGPU_RENDER_PASS_TIMESTAMP_WRITES_INIT as initializer.
- */
-typedef struct WGPURenderPassTimestampWrites {
-    WGPUChainedStruct const * nextInChain;
-    /**
-     * Query set to write timestamps to.
-     *
-     * The `INIT` macro sets this to `NULL`.
-     */
-    WGPUQuerySet querySet;
-    /**
-     * The `INIT` macro sets this to @ref WGPU_QUERY_SET_INDEX_UNDEFINED.
-     */
-    uint32_t beginningOfPassWriteIndex;
-    /**
-     * The `INIT` macro sets this to @ref WGPU_QUERY_SET_INDEX_UNDEFINED.
-     */
-    uint32_t endOfPassWriteIndex;
-} WGPURenderPassTimestampWrites WGPU_STRUCTURE_ATTRIBUTE;
-
-/**
- * Initializer for @ref WGPURenderPassTimestampWrites.
- */
-#define WGPU_RENDER_PASS_TIMESTAMP_WRITES_INIT _wgpu_MAKE_INIT_STRUCT(WGPURenderPassTimestampWrites, { \
-    /*.nextInChain=*/NULL _wgpu_COMMA \
-    /*.querySet=*/NULL _wgpu_COMMA \
-    /*.beginningOfPassWriteIndex=*/WGPU_QUERY_SET_INDEX_UNDEFINED _wgpu_COMMA \
-    /*.endOfPassWriteIndex=*/WGPU_QUERY_SET_INDEX_UNDEFINED _wgpu_COMMA \
 })
 
 /**
@@ -3488,7 +3456,7 @@ typedef struct WGPUComputePassDescriptor {
     /**
      * The `INIT` macro sets this to `NULL`.
      */
-    WGPU_NULLABLE WGPUComputePassTimestampWrites const * timestampWrites;
+    WGPU_NULLABLE WGPUPassTimestampWrites const * timestampWrites;
 } WGPUComputePassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 /**
@@ -4004,7 +3972,7 @@ typedef struct WGPURenderPassDescriptor {
     /**
      * The `INIT` macro sets this to `NULL`.
      */
-    WGPU_NULLABLE WGPURenderPassTimestampWrites const * timestampWrites;
+    WGPU_NULLABLE WGPUPassTimestampWrites const * timestampWrites;
 } WGPURenderPassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
 
 /**

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1823,28 +1823,9 @@ structs:
       - name: timestamp_writes
         doc: |
           TODO
-        type: struct.compute_pass_timestamp_writes
+        type: struct.pass_timestamp_writes
         pointer: immutable
         optional: true
-  - name: compute_pass_timestamp_writes
-    doc: |
-      TODO
-    type: base_in
-    members:
-      - name: query_set
-        doc: |
-          Query set to write timestamps to.
-        type: object.query_set
-      - name: beginning_of_pass_write_index
-        doc: |
-          TODO
-        type: uint32
-        default: constant.query_set_index_undefined
-      - name: end_of_pass_write_index
-        doc: |
-          TODO
-        type: uint32
-        default: constant.query_set_index_undefined
   - name: compute_pipeline_descriptor
     doc: |
       TODO
@@ -2255,6 +2236,25 @@ structs:
           TODO
         type: uint32
         default: 0
+  - name: pass_timestamp_writes
+    doc: |
+      TODO
+    type: base_in
+    members:
+      - name: query_set
+        doc: |
+          Query set to write timestamps to.
+        type: object.query_set
+      - name: beginning_of_pass_write_index
+        doc: |
+          TODO
+        type: uint32
+        default: constant.query_set_index_undefined
+      - name: end_of_pass_write_index
+        doc: |
+          TODO
+        type: uint32
+        default: constant.query_set_index_undefined
   - name: pipeline_layout_descriptor
     doc: |
       TODO
@@ -2475,7 +2475,7 @@ structs:
       - name: timestamp_writes
         doc: |
           TODO
-        type: struct.render_pass_timestamp_writes
+        type: struct.pass_timestamp_writes
         pointer: immutable
         optional: true
   - name: render_pass_max_draw_count
@@ -2490,25 +2490,6 @@ structs:
           TODO
         type: uint64
         default: 50000000
-  - name: render_pass_timestamp_writes
-    doc: |
-      TODO
-    type: base_in
-    members:
-      - name: query_set
-        doc: |
-          Query set to write timestamps to.
-        type: object.query_set
-      - name: beginning_of_pass_write_index
-        doc: |
-          TODO
-        type: uint32
-        default: constant.query_set_index_undefined
-      - name: end_of_pass_write_index
-        doc: |
-          TODO
-        type: uint32
-        default: constant.query_set_index_undefined
   - name: render_pipeline_descriptor
     doc: |
       TODO


### PR DESCRIPTION
If we need to extend TimestampWrites (e.g. with `end of vertex stage` or something) then we can still extend them off this struct, we'll just allow different extensions in different places.

(I previously wanted to avoid the allowed extensions being dependent on where the base struct is used, with extensibility of WGPUImageCopyTexture etc., but here it makes a lot more sense IMO as we have a much more concrete idea of what the extensions would be, and some could be shared. Still open to opinions if anyone thinks we should avoid this.)

Fixes #430