### PR TITLE
Set additionalProperties/unevaluatedProperties: false in schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema",
     "type": "object",
+    "additionalProperties": false,
     "definitions": {
         "Name": {
             "type": "string",
@@ -94,6 +95,7 @@
         },
         "Callback": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "name": {
                     "$ref": "#/definitions/Name",
@@ -122,6 +124,7 @@
         },
         "ParameterType": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "name": {
                     "$ref": "#/definitions/Name",
@@ -134,13 +137,9 @@
                     "$ref": "#/definitions/Type",
                     "description": "Parameter type"
                 },
-                "ownership": {
-                    "type": "string",
-                    "description": "Ownership of the value",
-                    "enum": [
-                        "with",
-                        "without"
-                    ]
+                "passed_with_ownership": {
+                    "type": "boolean",
+                    "description": "Whether the value is passed with ownership or without ownership"
                 },
                 "pointer": {
                     "$ref": "#/definitions/Pointer",
@@ -156,7 +155,11 @@
                     "pattern": "^[a-z]+$"
                 },
                 "default": {
-                    "type": [ "string", "number", "boolean" ],
+                    "type": [
+                        "string",
+                        "number",
+                        "boolean"
+                    ],
                     "description": "Default value assigned to this parameter when using initializer macro"
                 }
             },
@@ -167,6 +170,7 @@
             ]
         },
         "FunctionParameterType": {
+            "unevaluatedProperties": false,
             "allOf": [
                 {
                     "$ref": "#/definitions/ParameterType"
@@ -185,6 +189,7 @@
         },
         "Function": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "name": {
                     "$ref": "#/definitions/Name",
@@ -195,6 +200,7 @@
                 },
                 "returns": {
                     "type": "object",
+                    "additionalProperties": false,
                     "description": "Optional property, return type of the function",
                     "properties": {
                         "doc": {
@@ -254,6 +260,7 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "description": "An alias of a primitive type",
                 "properties": {
                     "name": {
@@ -277,6 +284,7 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "name": {
                         "$ref": "#/definitions/Name",
@@ -301,6 +309,7 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "name": {
                         "$ref": "#/definitions/Name",
@@ -323,6 +332,7 @@
                                 },
                                 {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "name": {
                                             "$ref": "#/definitions/Name",
@@ -355,6 +365,7 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "name": {
                         "$ref": "#/definitions/Name",
@@ -371,6 +382,7 @@
                         "type": "array",
                         "items": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "name": {
                                     "$ref": "#/definitions/Name",
@@ -408,6 +420,7 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "name": {
                         "$ref": "#/definitions/Name",
@@ -471,6 +484,7 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "name": {
                         "$ref": "#/definitions/Name",


### PR DESCRIPTION
Uses `additionalProperties: false` everywhere except in one place where we have to use the smarter `unevaluatedProperties: false` instead.

Fixes #312

Landing immediately since it's pretty trivial and can be reverted if needed for some reason.