### PR TITLE
Proposal: enums in INIT macros always use Undefined

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -1639,15 +1639,15 @@ typedef struct WGPUBindGroupEntry {
  */
 typedef struct WGPUBlendComponent {
     /**
-     * The `INIT` macro sets this to @ref WGPUBlendOperation_Add.
+     * The `INIT` macro sets this to @ref WGPUBlendOperation_Undefined.
      */
     WGPUBlendOperation operation;
     /**
-     * The `INIT` macro sets this to @ref WGPUBlendFactor_One.
+     * The `INIT` macro sets this to @ref WGPUBlendFactor_Undefined.
      */
     WGPUBlendFactor srcFactor;
     /**
-     * The `INIT` macro sets this to @ref WGPUBlendFactor_Zero.
+     * The `INIT` macro sets this to @ref WGPUBlendFactor_Undefined.
      */
     WGPUBlendFactor dstFactor;
 } WGPUBlendComponent WGPU_STRUCTURE_ATTRIBUTE;
@@ -1656,9 +1656,9 @@ typedef struct WGPUBlendComponent {
  * Initializer for @ref WGPUBlendComponent.
  */
 #define WGPU_BLEND_COMPONENT_INIT _wgpu_MAKE_INIT_STRUCT(WGPUBlendComponent, { \
-    /*.operation=*/WGPUBlendOperation_Add _wgpu_COMMA \
-    /*.srcFactor=*/WGPUBlendFactor_One _wgpu_COMMA \
-    /*.dstFactor=*/WGPUBlendFactor_Zero _wgpu_COMMA \
+    /*.operation=*/WGPUBlendOperation_Undefined _wgpu_COMMA \
+    /*.srcFactor=*/WGPUBlendFactor_Undefined _wgpu_COMMA \
+    /*.dstFactor=*/WGPUBlendFactor_Undefined _wgpu_COMMA \
 })
 
 /**
@@ -2254,7 +2254,7 @@ typedef struct WGPUPipelineLayoutDescriptor {
 typedef struct WGPUPrimitiveState {
     WGPUChainedStruct const * nextInChain;
     /**
-     * The `INIT` macro sets this to @ref WGPUPrimitiveTopology_TriangleList.
+     * The `INIT` macro sets this to @ref WGPUPrimitiveTopology_Undefined.
      */
     WGPUPrimitiveTopology topology;
     /**
@@ -2262,11 +2262,11 @@ typedef struct WGPUPrimitiveState {
      */
     WGPUIndexFormat stripIndexFormat;
     /**
-     * The `INIT` macro sets this to @ref WGPUFrontFace_CCW.
+     * The `INIT` macro sets this to @ref WGPUFrontFace_Undefined.
      */
     WGPUFrontFace frontFace;
     /**
-     * The `INIT` macro sets this to @ref WGPUCullMode_None.
+     * The `INIT` macro sets this to @ref WGPUCullMode_Undefined.
      */
     WGPUCullMode cullMode;
     /**
@@ -2280,10 +2280,10 @@ typedef struct WGPUPrimitiveState {
  */
 #define WGPU_PRIMITIVE_STATE_INIT _wgpu_MAKE_INIT_STRUCT(WGPUPrimitiveState, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
-    /*.topology=*/WGPUPrimitiveTopology_TriangleList _wgpu_COMMA \
+    /*.topology=*/WGPUPrimitiveTopology_Undefined _wgpu_COMMA \
     /*.stripIndexFormat=*/_wgpu_ENUM_ZERO_INIT(WGPUIndexFormat) _wgpu_COMMA \
-    /*.frontFace=*/WGPUFrontFace_CCW _wgpu_COMMA \
-    /*.cullMode=*/WGPUCullMode_None _wgpu_COMMA \
+    /*.frontFace=*/WGPUFrontFace_Undefined _wgpu_COMMA \
+    /*.cullMode=*/WGPUCullMode_Undefined _wgpu_COMMA \
     /*.unclippedDepth=*/0 _wgpu_COMMA \
 })
 
@@ -2501,7 +2501,7 @@ typedef struct WGPURequestAdapterOptions {
      * Additionally, implementations may ignore @ref WGPUFeatureLevel_Compatibility
      * and provide @ref WGPUFeatureLevel_Core instead.
      *
-     * The `INIT` macro sets this to @ref WGPUFeatureLevel_Core.
+     * The `INIT` macro sets this to @ref WGPUFeatureLevel_Undefined.
      */
     WGPUFeatureLevel featureLevel;
     /**
@@ -2536,7 +2536,7 @@ typedef struct WGPURequestAdapterOptions {
  */
 #define WGPU_REQUEST_ADAPTER_OPTIONS_INIT _wgpu_MAKE_INIT_STRUCT(WGPURequestAdapterOptions, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
-    /*.featureLevel=*/WGPUFeatureLevel_Core _wgpu_COMMA \
+    /*.featureLevel=*/WGPUFeatureLevel_Undefined _wgpu_COMMA \
     /*.powerPreference=*/WGPUPowerPreference_Undefined _wgpu_COMMA \
     /*.forceFallbackAdapter=*/0 _wgpu_COMMA \
     /*.backendType=*/WGPUBackendType_Undefined _wgpu_COMMA \
@@ -2574,27 +2574,27 @@ typedef struct WGPUSamplerDescriptor {
      */
     WGPUStringView label;
     /**
-     * The `INIT` macro sets this to @ref WGPUAddressMode_ClampToEdge.
+     * The `INIT` macro sets this to @ref WGPUAddressMode_Undefined.
      */
     WGPUAddressMode addressModeU;
     /**
-     * The `INIT` macro sets this to @ref WGPUAddressMode_ClampToEdge.
+     * The `INIT` macro sets this to @ref WGPUAddressMode_Undefined.
      */
     WGPUAddressMode addressModeV;
     /**
-     * The `INIT` macro sets this to @ref WGPUAddressMode_ClampToEdge.
+     * The `INIT` macro sets this to @ref WGPUAddressMode_Undefined.
      */
     WGPUAddressMode addressModeW;
     /**
-     * The `INIT` macro sets this to @ref WGPUFilterMode_Nearest.
+     * The `INIT` macro sets this to @ref WGPUFilterMode_Undefined.
      */
     WGPUFilterMode magFilter;
     /**
-     * The `INIT` macro sets this to @ref WGPUFilterMode_Nearest.
+     * The `INIT` macro sets this to @ref WGPUFilterMode_Undefined.
      */
     WGPUFilterMode minFilter;
     /**
-     * The `INIT` macro sets this to @ref WGPUMipmapFilterMode_Nearest.
+     * The `INIT` macro sets this to @ref WGPUMipmapFilterMode_Undefined.
      */
     WGPUMipmapFilterMode mipmapFilter;
     /**
@@ -2621,12 +2621,12 @@ typedef struct WGPUSamplerDescriptor {
 #define WGPU_SAMPLER_DESCRIPTOR_INIT _wgpu_MAKE_INIT_STRUCT(WGPUSamplerDescriptor, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
     /*.label=*/WGPU_STRING_VIEW_INIT _wgpu_COMMA \
-    /*.addressModeU=*/WGPUAddressMode_ClampToEdge _wgpu_COMMA \
-    /*.addressModeV=*/WGPUAddressMode_ClampToEdge _wgpu_COMMA \
-    /*.addressModeW=*/WGPUAddressMode_ClampToEdge _wgpu_COMMA \
-    /*.magFilter=*/WGPUFilterMode_Nearest _wgpu_COMMA \
-    /*.minFilter=*/WGPUFilterMode_Nearest _wgpu_COMMA \
-    /*.mipmapFilter=*/WGPUMipmapFilterMode_Nearest _wgpu_COMMA \
+    /*.addressModeU=*/WGPUAddressMode_Undefined _wgpu_COMMA \
+    /*.addressModeV=*/WGPUAddressMode_Undefined _wgpu_COMMA \
+    /*.addressModeW=*/WGPUAddressMode_Undefined _wgpu_COMMA \
+    /*.magFilter=*/WGPUFilterMode_Undefined _wgpu_COMMA \
+    /*.minFilter=*/WGPUFilterMode_Undefined _wgpu_COMMA \
+    /*.mipmapFilter=*/WGPUMipmapFilterMode_Undefined _wgpu_COMMA \
     /*.lodMinClamp=*/0.f _wgpu_COMMA \
     /*.lodMaxClamp=*/32.f _wgpu_COMMA \
     /*.compare=*/WGPUCompareFunction_Undefined _wgpu_COMMA \
@@ -2710,19 +2710,19 @@ typedef struct WGPUShaderSourceWGSL {
  */
 typedef struct WGPUStencilFaceState {
     /**
-     * The `INIT` macro sets this to @ref WGPUCompareFunction_Always.
+     * The `INIT` macro sets this to @ref WGPUCompareFunction_Undefined.
      */
     WGPUCompareFunction compare;
     /**
-     * The `INIT` macro sets this to @ref WGPUStencilOperation_Keep.
+     * The `INIT` macro sets this to @ref WGPUStencilOperation_Undefined.
      */
     WGPUStencilOperation failOp;
     /**
-     * The `INIT` macro sets this to @ref WGPUStencilOperation_Keep.
+     * The `INIT` macro sets this to @ref WGPUStencilOperation_Undefined.
      */
     WGPUStencilOperation depthFailOp;
     /**
-     * The `INIT` macro sets this to @ref WGPUStencilOperation_Keep.
+     * The `INIT` macro sets this to @ref WGPUStencilOperation_Undefined.
      */
     WGPUStencilOperation passOp;
 } WGPUStencilFaceState WGPU_STRUCTURE_ATTRIBUTE;
@@ -2731,10 +2731,10 @@ typedef struct WGPUStencilFaceState {
  * Initializer for @ref WGPUStencilFaceState.
  */
 #define WGPU_STENCIL_FACE_STATE_INIT _wgpu_MAKE_INIT_STRUCT(WGPUStencilFaceState, { \
-    /*.compare=*/WGPUCompareFunction_Always _wgpu_COMMA \
-    /*.failOp=*/WGPUStencilOperation_Keep _wgpu_COMMA \
-    /*.depthFailOp=*/WGPUStencilOperation_Keep _wgpu_COMMA \
-    /*.passOp=*/WGPUStencilOperation_Keep _wgpu_COMMA \
+    /*.compare=*/WGPUCompareFunction_Undefined _wgpu_COMMA \
+    /*.failOp=*/WGPUStencilOperation_Undefined _wgpu_COMMA \
+    /*.depthFailOp=*/WGPUStencilOperation_Undefined _wgpu_COMMA \
+    /*.passOp=*/WGPUStencilOperation_Undefined _wgpu_COMMA \
 })
 
 /**
@@ -2751,7 +2751,7 @@ typedef struct WGPUStorageTextureBindingLayout {
      */
     WGPUTextureFormat format;
     /**
-     * The `INIT` macro sets this to @ref WGPUTextureViewDimension_2D.
+     * The `INIT` macro sets this to @ref WGPUTextureViewDimension_Undefined.
      */
     WGPUTextureViewDimension viewDimension;
 } WGPUStorageTextureBindingLayout WGPU_STRUCTURE_ATTRIBUTE;
@@ -2763,7 +2763,7 @@ typedef struct WGPUStorageTextureBindingLayout {
     /*.nextInChain=*/NULL _wgpu_COMMA \
     /*.access=*/WGPUStorageTextureAccess_BindingNotUsed _wgpu_COMMA \
     /*.format=*/WGPUTextureFormat_Undefined _wgpu_COMMA \
-    /*.viewDimension=*/WGPUTextureViewDimension_2D _wgpu_COMMA \
+    /*.viewDimension=*/WGPUTextureViewDimension_Undefined _wgpu_COMMA \
 })
 
 /**
@@ -2911,7 +2911,7 @@ typedef struct WGPUSurfaceConfiguration {
     /**
      * When and in which order the surface's frames will be shown on the screen. Defaults to @ref WGPUPresentMode_Fifo.
      *
-     * The `INIT` macro sets this to @ref WGPUPresentMode_Fifo.
+     * The `INIT` macro sets this to @ref WGPUPresentMode_Undefined.
      */
     WGPUPresentMode presentMode;
 } WGPUSurfaceConfiguration WGPU_STRUCTURE_ATTRIBUTE;
@@ -2929,7 +2929,7 @@ typedef struct WGPUSurfaceConfiguration {
     /*.viewFormatCount=*/0 _wgpu_COMMA \
     /*.viewFormats=*/NULL _wgpu_COMMA \
     /*.alphaMode=*/WGPUCompositeAlphaMode_Auto _wgpu_COMMA \
-    /*.presentMode=*/WGPUPresentMode_Fifo _wgpu_COMMA \
+    /*.presentMode=*/WGPUPresentMode_Undefined _wgpu_COMMA \
 })
 
 /**
@@ -3213,7 +3213,7 @@ typedef struct WGPUTextureBindingLayout {
      */
     WGPUTextureSampleType sampleType;
     /**
-     * The `INIT` macro sets this to @ref WGPUTextureViewDimension_2D.
+     * The `INIT` macro sets this to @ref WGPUTextureViewDimension_Undefined.
      */
     WGPUTextureViewDimension viewDimension;
     /**
@@ -3228,7 +3228,7 @@ typedef struct WGPUTextureBindingLayout {
 #define WGPU_TEXTURE_BINDING_LAYOUT_INIT _wgpu_MAKE_INIT_STRUCT(WGPUTextureBindingLayout, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
     /*.sampleType=*/WGPUTextureSampleType_BindingNotUsed _wgpu_COMMA \
-    /*.viewDimension=*/WGPUTextureViewDimension_2D _wgpu_COMMA \
+    /*.viewDimension=*/WGPUTextureViewDimension_Undefined _wgpu_COMMA \
     /*.multisampled=*/0 _wgpu_COMMA \
 })
 
@@ -3268,7 +3268,7 @@ typedef struct WGPUTextureViewDescriptor {
      */
     uint32_t arrayLayerCount;
     /**
-     * The `INIT` macro sets this to @ref WGPUTextureAspect_All.
+     * The `INIT` macro sets this to @ref WGPUTextureAspect_Undefined.
      */
     WGPUTextureAspect aspect;
     /**
@@ -3289,7 +3289,7 @@ typedef struct WGPUTextureViewDescriptor {
     /*.mipLevelCount=*/WGPU_MIP_LEVEL_COUNT_UNDEFINED _wgpu_COMMA \
     /*.baseArrayLayer=*/0 _wgpu_COMMA \
     /*.arrayLayerCount=*/WGPU_ARRAY_LAYER_COUNT_UNDEFINED _wgpu_COMMA \
-    /*.aspect=*/WGPUTextureAspect_All _wgpu_COMMA \
+    /*.aspect=*/WGPUTextureAspect_Undefined _wgpu_COMMA \
     /*.usage=*/WGPUTextureUsage_None _wgpu_COMMA \
 })
 
@@ -3748,7 +3748,7 @@ typedef struct WGPUTexelCopyTextureInfo {
      */
     WGPUOrigin3D origin;
     /**
-     * The `INIT` macro sets this to @ref WGPUTextureAspect_All.
+     * The `INIT` macro sets this to @ref WGPUTextureAspect_Undefined.
      */
     WGPUTextureAspect aspect;
 } WGPUTexelCopyTextureInfo WGPU_STRUCTURE_ATTRIBUTE;
@@ -3760,7 +3760,7 @@ typedef struct WGPUTexelCopyTextureInfo {
     /*.texture=*/NULL _wgpu_COMMA \
     /*.mipLevel=*/0 _wgpu_COMMA \
     /*.origin=*/WGPU_ORIGIN_3D_INIT _wgpu_COMMA \
-    /*.aspect=*/WGPUTextureAspect_All _wgpu_COMMA \
+    /*.aspect=*/WGPUTextureAspect_Undefined _wgpu_COMMA \
 })
 
 /**
@@ -3779,7 +3779,7 @@ typedef struct WGPUTextureDescriptor {
      */
     WGPUTextureUsage usage;
     /**
-     * The `INIT` macro sets this to @ref WGPUTextureDimension_2D.
+     * The `INIT` macro sets this to @ref WGPUTextureDimension_Undefined.
      */
     WGPUTextureDimension dimension;
     /**
@@ -3812,7 +3812,7 @@ typedef struct WGPUTextureDescriptor {
     /*.nextInChain=*/NULL _wgpu_COMMA \
     /*.label=*/WGPU_STRING_VIEW_INIT _wgpu_COMMA \
     /*.usage=*/WGPUTextureUsage_None _wgpu_COMMA \
-    /*.dimension=*/WGPUTextureDimension_2D _wgpu_COMMA \
+    /*.dimension=*/WGPUTextureDimension_Undefined _wgpu_COMMA \
     /*.size=*/WGPU_EXTENT_3D_INIT _wgpu_COMMA \
     /*.format=*/WGPUTextureFormat_Undefined _wgpu_COMMA \
     /*.mipLevelCount=*/1 _wgpu_COMMA \

--- a/webgpu.h
+++ b/webgpu.h
@@ -1639,14 +1639,20 @@ typedef struct WGPUBindGroupEntry {
  */
 typedef struct WGPUBlendComponent {
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUBlendOperation_Add.
+     *
      * The `INIT` macro sets this to @ref WGPUBlendOperation_Undefined.
      */
     WGPUBlendOperation operation;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUBlendFactor_One.
+     *
      * The `INIT` macro sets this to @ref WGPUBlendFactor_Undefined.
      */
     WGPUBlendFactor srcFactor;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUBlendFactor_Zero.
+     *
      * The `INIT` macro sets this to @ref WGPUBlendFactor_Undefined.
      */
     WGPUBlendFactor dstFactor;
@@ -2254,6 +2260,8 @@ typedef struct WGPUPipelineLayoutDescriptor {
 typedef struct WGPUPrimitiveState {
     WGPUChainedStruct const * nextInChain;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUPrimitiveTopology_TriangleList.
+     *
      * The `INIT` macro sets this to @ref WGPUPrimitiveTopology_Undefined.
      */
     WGPUPrimitiveTopology topology;
@@ -2262,10 +2270,14 @@ typedef struct WGPUPrimitiveState {
      */
     WGPUIndexFormat stripIndexFormat;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUFrontFace_CCW.
+     *
      * The `INIT` macro sets this to @ref WGPUFrontFace_Undefined.
      */
     WGPUFrontFace frontFace;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUCullMode_None.
+     *
      * The `INIT` macro sets this to @ref WGPUCullMode_Undefined.
      */
     WGPUCullMode cullMode;
@@ -2497,7 +2509,7 @@ typedef struct WGPURequestAdapterOptions {
     /**
      * "Feature level" for the adapter request. If an adapter is returned, it must support the features and limits in the requested feature level.
      *
-     * If not specified, the default is @ref WGPUFeatureLevel_Core.
+     * [Defaults](@ref SentinelValues) to @ref WGPUFeatureLevel_Core.
      * Additionally, implementations may ignore @ref WGPUFeatureLevel_Compatibility
      * and provide @ref WGPUFeatureLevel_Core instead.
      *
@@ -2574,26 +2586,38 @@ typedef struct WGPUSamplerDescriptor {
      */
     WGPUStringView label;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUAddressMode_ClampToEdge.
+     *
      * The `INIT` macro sets this to @ref WGPUAddressMode_Undefined.
      */
     WGPUAddressMode addressModeU;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUAddressMode_ClampToEdge.
+     *
      * The `INIT` macro sets this to @ref WGPUAddressMode_Undefined.
      */
     WGPUAddressMode addressModeV;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUAddressMode_ClampToEdge.
+     *
      * The `INIT` macro sets this to @ref WGPUAddressMode_Undefined.
      */
     WGPUAddressMode addressModeW;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUFilterMode_Nearest.
+     *
      * The `INIT` macro sets this to @ref WGPUFilterMode_Undefined.
      */
     WGPUFilterMode magFilter;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUFilterMode_Nearest.
+     *
      * The `INIT` macro sets this to @ref WGPUFilterMode_Undefined.
      */
     WGPUFilterMode minFilter;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUMipmapFilterMode_Nearest.
+     *
      * The `INIT` macro sets this to @ref WGPUMipmapFilterMode_Undefined.
      */
     WGPUMipmapFilterMode mipmapFilter;
@@ -2710,18 +2734,26 @@ typedef struct WGPUShaderSourceWGSL {
  */
 typedef struct WGPUStencilFaceState {
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUCompareFunction_Always.
+     *
      * The `INIT` macro sets this to @ref WGPUCompareFunction_Undefined.
      */
     WGPUCompareFunction compare;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUStencilOperation_Keep.
+     *
      * The `INIT` macro sets this to @ref WGPUStencilOperation_Undefined.
      */
     WGPUStencilOperation failOp;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUStencilOperation_Keep.
+     *
      * The `INIT` macro sets this to @ref WGPUStencilOperation_Undefined.
      */
     WGPUStencilOperation depthFailOp;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUStencilOperation_Keep.
+     *
      * The `INIT` macro sets this to @ref WGPUStencilOperation_Undefined.
      */
     WGPUStencilOperation passOp;
@@ -2751,6 +2783,8 @@ typedef struct WGPUStorageTextureBindingLayout {
      */
     WGPUTextureFormat format;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUTextureViewDimension_2D.
+     *
      * The `INIT` macro sets this to @ref WGPUTextureViewDimension_Undefined.
      */
     WGPUTextureViewDimension viewDimension;
@@ -2909,7 +2943,9 @@ typedef struct WGPUSurfaceConfiguration {
      */
     WGPUCompositeAlphaMode alphaMode;
     /**
-     * When and in which order the surface's frames will be shown on the screen. Defaults to @ref WGPUPresentMode_Fifo.
+     * When and in which order the surface's frames will be shown on the screen.
+     *
+     * [Defaults](@ref SentinelValues) to @ref WGPUPresentMode_Fifo.
      *
      * The `INIT` macro sets this to @ref WGPUPresentMode_Undefined.
      */
@@ -3213,6 +3249,8 @@ typedef struct WGPUTextureBindingLayout {
      */
     WGPUTextureSampleType sampleType;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUTextureViewDimension_2D.
+     *
      * The `INIT` macro sets this to @ref WGPUTextureViewDimension_Undefined.
      */
     WGPUTextureViewDimension viewDimension;
@@ -3268,6 +3306,8 @@ typedef struct WGPUTextureViewDescriptor {
      */
     uint32_t arrayLayerCount;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUTextureAspect_All.
+     *
      * The `INIT` macro sets this to @ref WGPUTextureAspect_Undefined.
      */
     WGPUTextureAspect aspect;
@@ -3748,6 +3788,8 @@ typedef struct WGPUTexelCopyTextureInfo {
      */
     WGPUOrigin3D origin;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUTextureAspect_All.
+     *
      * The `INIT` macro sets this to @ref WGPUTextureAspect_Undefined.
      */
     WGPUTextureAspect aspect;
@@ -3779,6 +3821,8 @@ typedef struct WGPUTextureDescriptor {
      */
     WGPUTextureUsage usage;
     /**
+     * [Defaults](@ref SentinelValues) to @ref WGPUTextureDimension_2D.
+     *
      * The `INIT` macro sets this to @ref WGPUTextureDimension_Undefined.
      */
     WGPUTextureDimension dimension;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1641,17 +1641,17 @@ structs:
     members:
       - name: operation
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUBlendOperation_Add.
         type: enum.blend_operation
         default: undefined
       - name: src_factor
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUBlendFactor_One.
         type: enum.blend_factor
         default: undefined
       - name: dst_factor
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUBlendFactor_Zero.
         type: enum.blend_factor
         default: undefined
   - name: blend_state
@@ -2276,7 +2276,7 @@ structs:
     members:
       - name: topology
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUPrimitiveTopology_TriangleList.
         type: enum.primitive_topology
         default: undefined
       - name: strip_index_format
@@ -2285,12 +2285,12 @@ structs:
         type: enum.index_format
       - name: front_face
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUFrontFace_CCW.
         type: enum.front_face
         default: undefined
       - name: cull_mode
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUCullMode_None.
         type: enum.cull_mode
         default: undefined
       - name: unclipped_depth
@@ -2538,7 +2538,7 @@ structs:
         doc: |
           "Feature level" for the adapter request. If an adapter is returned, it must support the features and limits in the requested feature level.
 
-          If not specified, the default is @ref WGPUFeatureLevel_Core.
+          [Defaults](@ref SentinelValues) to @ref WGPUFeatureLevel_Core.
           Additionally, implementations may ignore @ref WGPUFeatureLevel_Compatibility
           and provide @ref WGPUFeatureLevel_Core instead.
         type: enum.feature_level
@@ -2587,32 +2587,32 @@ structs:
         type: string_with_default_empty
       - name: address_mode_u
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUAddressMode_ClampToEdge.
         type: enum.address_mode
         default: undefined
       - name: address_mode_v
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUAddressMode_ClampToEdge.
         type: enum.address_mode
         default: undefined
       - name: address_mode_w
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUAddressMode_ClampToEdge.
         type: enum.address_mode
         default: undefined
       - name: mag_filter
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUFilterMode_Nearest.
         type: enum.filter_mode
         default: undefined
       - name: min_filter
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUFilterMode_Nearest.
         type: enum.filter_mode
         default: undefined
       - name: mipmap_filter
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUMipmapFilterMode_Nearest.
         type: enum.mipmap_filter_mode
         default: undefined
       - name: lod_min_clamp
@@ -2679,22 +2679,22 @@ structs:
     members:
       - name: compare
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUCompareFunction_Always.
         type: enum.compare_function
         default: undefined
       - name: fail_op
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUStencilOperation_Keep.
         type: enum.stencil_operation
         default: undefined
       - name: depth_fail_op
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUStencilOperation_Keep.
         type: enum.stencil_operation
         default: undefined
       - name: pass_op
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUStencilOperation_Keep.
         type: enum.stencil_operation
         default: undefined
   - name: storage_texture_binding_layout
@@ -2714,7 +2714,7 @@ structs:
         default: undefined
       - name: view_dimension
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUTextureViewDimension_2D.
         type: enum.texture_view_dimension
         default: undefined
   - name: supported_features
@@ -2797,7 +2797,10 @@ structs:
         type: enum.composite_alpha_mode
         default: auto
       - name: present_mode
-        doc: When and in which order the surface's frames will be shown on the screen. Defaults to @ref WGPUPresentMode_Fifo.
+        doc: |
+          When and in which order the surface's frames will be shown on the screen.
+
+          [Defaults](@ref SentinelValues) to @ref WGPUPresentMode_Fifo.
         type: enum.present_mode
         default: undefined
   - name: surface_descriptor
@@ -2953,7 +2956,7 @@ structs:
         type: struct.origin_3D
       - name: aspect
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUTextureAspect_All.
         type: enum.texture_aspect
         default: undefined
   - name: texture_binding_layout
@@ -2968,7 +2971,7 @@ structs:
         default: binding_not_used
       - name: view_dimension
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUTextureViewDimension_2D.
         type: enum.texture_view_dimension
         default: undefined
       - name: multisampled
@@ -2992,7 +2995,7 @@ structs:
         default: none
       - name: dimension
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUTextureDimension_2D.
         type: enum.texture_dimension
         default: undefined
       - name: size
@@ -3060,7 +3063,7 @@ structs:
         default: constant.array_layer_count_undefined
       - name: aspect
         doc: |
-          TODO
+          [Defaults](@ref SentinelValues) to @ref WGPUTextureAspect_All.
         type: enum.texture_aspect
         default: undefined
       - name: usage

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1643,17 +1643,17 @@ structs:
         doc: |
           TODO
         type: enum.blend_operation
-        default: add
+        default: undefined
       - name: src_factor
         doc: |
           TODO
         type: enum.blend_factor
-        default: one
+        default: undefined
       - name: dst_factor
         doc: |
           TODO
         type: enum.blend_factor
-        default: zero
+        default: undefined
   - name: blend_state
     doc: |
       TODO
@@ -2278,7 +2278,7 @@ structs:
         doc: |
           TODO
         type: enum.primitive_topology
-        default: triangle_list
+        default: undefined
       - name: strip_index_format
         doc: |
           TODO
@@ -2287,12 +2287,12 @@ structs:
         doc: |
           TODO
         type: enum.front_face
-        default: CCW
+        default: undefined
       - name: cull_mode
         doc: |
           TODO
         type: enum.cull_mode
-        default: none
+        default: undefined
       - name: unclipped_depth
         doc: |
           TODO
@@ -2542,7 +2542,7 @@ structs:
           Additionally, implementations may ignore @ref WGPUFeatureLevel_Compatibility
           and provide @ref WGPUFeatureLevel_Core instead.
         type: enum.feature_level
-        default: core
+        default: undefined
       - name: power_preference
         doc: |
           TODO
@@ -2589,32 +2589,32 @@ structs:
         doc: |
           TODO
         type: enum.address_mode
-        default: clamp_to_edge
+        default: undefined
       - name: address_mode_v
         doc: |
           TODO
         type: enum.address_mode
-        default: clamp_to_edge
+        default: undefined
       - name: address_mode_w
         doc: |
           TODO
         type: enum.address_mode
-        default: clamp_to_edge
+        default: undefined
       - name: mag_filter
         doc: |
           TODO
         type: enum.filter_mode
-        default: nearest
+        default: undefined
       - name: min_filter
         doc: |
           TODO
         type: enum.filter_mode
-        default: nearest
+        default: undefined
       - name: mipmap_filter
         doc: |
           TODO
         type: enum.mipmap_filter_mode
-        default: nearest
+        default: undefined
       - name: lod_min_clamp
         doc: |
           TODO
@@ -2681,22 +2681,22 @@ structs:
         doc: |
           TODO
         type: enum.compare_function
-        default: always
+        default: undefined
       - name: fail_op
         doc: |
           TODO
         type: enum.stencil_operation
-        default: keep
+        default: undefined
       - name: depth_fail_op
         doc: |
           TODO
         type: enum.stencil_operation
-        default: keep
+        default: undefined
       - name: pass_op
         doc: |
           TODO
         type: enum.stencil_operation
-        default: keep
+        default: undefined
   - name: storage_texture_binding_layout
     doc: |
       TODO
@@ -2716,7 +2716,7 @@ structs:
         doc: |
           TODO
         type: enum.texture_view_dimension
-        default: 2D
+        default: undefined
   - name: supported_features
     doc: |
       TODO
@@ -2799,7 +2799,7 @@ structs:
       - name: present_mode
         doc: When and in which order the surface's frames will be shown on the screen. Defaults to @ref WGPUPresentMode_Fifo.
         type: enum.present_mode
-        default: fifo
+        default: undefined
   - name: surface_descriptor
     doc: |
       The root descriptor for the creation of an @ref WGPUSurface with @ref wgpuInstanceCreateSurface.
@@ -2955,7 +2955,7 @@ structs:
         doc: |
           TODO
         type: enum.texture_aspect
-        default: all
+        default: undefined
   - name: texture_binding_layout
     doc: |
       TODO
@@ -2970,7 +2970,7 @@ structs:
         doc: |
           TODO
         type: enum.texture_view_dimension
-        default: 2D
+        default: undefined
       - name: multisampled
         doc: |
           TODO
@@ -2994,7 +2994,7 @@ structs:
         doc: |
           TODO
         type: enum.texture_dimension
-        default: 2D
+        default: undefined
       - name: size
         doc: |
           TODO
@@ -3062,7 +3062,7 @@ structs:
         doc: |
           TODO
         type: enum.texture_aspect
-        default: all
+        default: undefined
       - name: usage
         doc: |
           TODO


### PR DESCRIPTION
The actual default may be dependent on where the struct is used, or could be changed from a trivial default to a non-trivial default in the future.

The `Undefined` enum values (or `WGPUCompositeAlphaMode_Auto`) are defined to always do the defaulting inside the API regardless of whether it's a trivial default or not.

All enum fields (searched for `type: enum\..*\n\s*default: `) now use `Undefined`(/`Auto`) or `*NotUsed`. (except for #445)

I also added documentation to all the ones I changed, explaining the default. All of the others are either optional or required in the JS spec, so should be fairly clear.

I might turn the defaulting/optional/required docs into something more generated later, but for now this does what we need.