### PR TITLE
Fixes for return type docs

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -47,10 +47,10 @@ func (g *Generator) Gen(dst io.Writer) error {
 					}
 				}
 				for _, arg := range fn.Args {
-					var argDoc = strings.TrimSpace(arg.Doc)
+					argDoc := strings.TrimSpace(arg.Doc)
 					var sArg string
 					if argDoc != "" && argDoc != "TODO" {
-						sArg += argDoc
+						sArg = argDoc
 					}
 
 					if arg.PassedWithOwnership != nil {
@@ -68,8 +68,22 @@ func (g *Generator) Gen(dst io.Writer) error {
 				}
 				if fn.Returns != nil {
 					returnsDoc := strings.TrimSpace(fn.Returns.Doc)
+					var sRet string
 					if returnsDoc != "" && returnsDoc != "TODO" {
-						s += "\n\n@returns\n" + returnsDoc
+						sRet = returnsDoc
+					}
+
+					if fn.Returns.PassedWithOwnership != nil {
+						if *fn.Returns.PassedWithOwnership {
+							sRet += "\nThis value is @ref ReturnedWithOwnership."
+						} else {
+							panic("invalid")
+						}
+					}
+
+					sRet = strings.TrimSpace(sRet)
+					if sRet != "" {
+						s += "\n\n@returns\n" + sRet
 					}
 				}
 				return Comment(strings.TrimSpace(s), CommentTypeMultiLine, indent, true)

--- a/schema.json
+++ b/schema.json
@@ -204,7 +204,9 @@
                     "description": "Optional property, return type of the function",
                     "properties": {
                         "doc": {
-                            "type": "string"
+                            "type": "string",
+                            "$comment": "Doxygen doesn't support multi-paragraph return docs (containing \\n\\n)",
+                            "pattern": "^\n?.+(\n.+)*\n?$"
                         },
                         "type": {
                             "$ref": "#/definitions/Type",

--- a/webgpu.h
+++ b/webgpu.h
@@ -5264,7 +5264,6 @@ WGPU_EXPORT void wgpuBufferDestroy(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
  * Returns a const pointer to beginning of the mapped range.
  * It must not be written; writing to this range causes undefined behavior.
  * Returns `NULL` with @ref ImplementationDefinedLogging if:
- *
  * - There is any content-timeline error as defined in the WebGPU specification for `getMappedRange()` (alignments, overlaps, etc.)
  *   **except** for overlaps with other *const* ranges, which are allowed in C.
  *   (JS does not allow this because const ranges do not exist.)
@@ -5281,7 +5280,6 @@ WGPU_EXPORT WGPUBufferMapState wgpuBufferGetMapState(WGPUBuffer buffer) WGPU_FUN
  * @returns
  * Returns a mutable pointer to beginning of the mapped range.
  * Returns `NULL` with @ref ImplementationDefinedLogging if:
- *
  * - There is any content-timeline error as defined in the WebGPU specification for `getMappedRange()` (alignments, overlaps, etc.)
  * - The buffer is not mapped with @ref WGPUMapMode_Write.
  */

--- a/webgpu.h
+++ b/webgpu.h
@@ -5144,6 +5144,9 @@ typedef void (*WGPUProcTextureViewRelease)(WGPUTextureView textureView) WGPU_FUN
  */
 /**
  * Create a WGPUInstance
+ *
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
  */
 WGPU_EXPORT WGPUInstance wgpuCreateInstance(WGPU_NULLABLE WGPUInstanceDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 /**
@@ -5314,13 +5317,25 @@ WGPU_EXPORT void wgpuCommandBufferRelease(WGPUCommandBuffer commandBuffer) WGPU_
  *
  * @{
  */
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUComputePassEncoder wgpuCommandEncoderBeginComputePass(WGPUCommandEncoder commandEncoder, WGPU_NULLABLE WGPUComputePassDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder commandEncoder, WGPURenderPassDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderClearBuffer(WGPUCommandEncoder commandEncoder, WGPUBuffer buffer, uint64_t offset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderCopyBufferToBuffer(WGPUCommandEncoder commandEncoder, WGPUBuffer source, uint64_t sourceOffset, WGPUBuffer destination, uint64_t destinationOffset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderCopyBufferToTexture(WGPUCommandEncoder commandEncoder, WGPUTexelCopyBufferInfo const * source, WGPUTexelCopyTextureInfo const * destination, WGPUExtent3D const * copySize) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderCopyTextureToBuffer(WGPUCommandEncoder commandEncoder, WGPUTexelCopyTextureInfo const * source, WGPUTexelCopyBufferInfo const * destination, WGPUExtent3D const * copySize) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderCopyTextureToTexture(WGPUCommandEncoder commandEncoder, WGPUTexelCopyTextureInfo const * source, WGPUTexelCopyTextureInfo const * destination, WGPUExtent3D const * copySize) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUCommandBuffer wgpuCommandEncoderFinish(WGPUCommandEncoder commandEncoder, WGPU_NULLABLE WGPUCommandBufferDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderInsertDebugMarker(WGPUCommandEncoder commandEncoder, WGPUStringView markerLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandEncoderPopDebugGroup(WGPUCommandEncoder commandEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -5361,6 +5376,10 @@ WGPU_EXPORT void wgpuComputePassEncoderRelease(WGPUComputePassEncoder computePas
  *
  * @{
  */
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUBindGroupLayout wgpuComputePipelineGetBindGroupLayout(WGPUComputePipeline computePipeline, uint32_t groupIndex) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePipelineSetLabel(WGPUComputePipeline computePipeline, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePipelineAddRef(WGPUComputePipeline computePipeline) WGPU_FUNCTION_ATTRIBUTE;
@@ -5375,19 +5394,67 @@ WGPU_EXPORT void wgpuComputePipelineRelease(WGPUComputePipeline computePipeline)
  *
  * @{
  */
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUBindGroup wgpuDeviceCreateBindGroup(WGPUDevice device, WGPUBindGroupDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUBindGroupLayout wgpuDeviceCreateBindGroupLayout(WGPUDevice device, WGPUBindGroupLayoutDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUBuffer wgpuDeviceCreateBuffer(WGPUDevice device, WGPUBufferDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUCommandEncoder wgpuDeviceCreateCommandEncoder(WGPUDevice device, WGPU_NULLABLE WGPUCommandEncoderDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUComputePipeline wgpuDeviceCreateComputePipeline(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUFuture wgpuDeviceCreateComputePipelineAsync(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor, WGPUCreateComputePipelineAsyncCallbackInfo callbackInfo) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUPipelineLayout wgpuDeviceCreatePipelineLayout(WGPUDevice device, WGPUPipelineLayoutDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUQuerySet wgpuDeviceCreateQuerySet(WGPUDevice device, WGPUQuerySetDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPURenderBundleEncoder wgpuDeviceCreateRenderBundleEncoder(WGPUDevice device, WGPURenderBundleEncoderDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPURenderPipeline wgpuDeviceCreateRenderPipeline(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUFuture wgpuDeviceCreateRenderPipelineAsync(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor, WGPUCreateRenderPipelineAsyncCallbackInfo callbackInfo) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUSampler wgpuDeviceCreateSampler(WGPUDevice device, WGPU_NULLABLE WGPUSamplerDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUShaderModule wgpuDeviceCreateShaderModule(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUTexture wgpuDeviceCreateTexture(WGPUDevice device, WGPUTextureDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuDeviceDestroy(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 /**
@@ -5415,6 +5482,10 @@ WGPU_EXPORT WGPUStatus wgpuDeviceGetLimits(WGPUDevice device, WGPULimits * limit
  * The @ref WGPUFuture for the device-lost event of the device.
  */
 WGPU_EXPORT WGPUFuture wgpuDeviceGetLostFuture(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPUQueue wgpuDeviceGetQueue(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBool wgpuDeviceHasFeature(WGPUDevice device, WGPUFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUFuture wgpuDevicePopErrorScope(WGPUDevice device, WGPUPopErrorScopeCallbackInfo callbackInfo) WGPU_FUNCTION_ATTRIBUTE;
@@ -5440,6 +5511,7 @@ WGPU_EXPORT void wgpuDeviceRelease(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
  *
  * @returns
  * A new @ref WGPUSurface for this descriptor (or an error @ref WGPUSurface).
+ * This value is @ref ReturnedWithOwnership.
  */
 WGPU_EXPORT WGPUSurface wgpuInstanceCreateSurface(WGPUInstance instance, WGPUSurfaceDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 /**
@@ -5539,6 +5611,10 @@ WGPU_EXPORT void wgpuRenderBundleEncoderDraw(WGPURenderBundleEncoder renderBundl
 WGPU_EXPORT void wgpuRenderBundleEncoderDrawIndexed(WGPURenderBundleEncoder renderBundleEncoder, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderDrawIndexedIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderDrawIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
+ */
 WGPU_EXPORT WGPURenderBundle wgpuRenderBundleEncoderFinish(WGPURenderBundleEncoder renderBundleEncoder, WGPU_NULLABLE WGPURenderBundleDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderInsertDebugMarker(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView markerLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderPopDebugGroup(WGPURenderBundleEncoder renderBundleEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -5591,6 +5667,10 @@ WGPU_EXPORT void wgpuRenderPassEncoderRelease(WGPURenderPassEncoder renderPassEn
  * \brief Functions whose first argument has type WGPURenderPipeline.
  *
  * @{
+ */
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
  */
 WGPU_EXPORT WGPUBindGroupLayout wgpuRenderPipelineGetBindGroupLayout(WGPURenderPipeline renderPipeline, uint32_t groupIndex) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPipelineSetLabel(WGPURenderPipeline renderPipeline, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
@@ -5742,6 +5822,10 @@ WGPU_EXPORT void wgpuSurfaceCapabilitiesFreeMembers(WGPUSurfaceCapabilities surf
  * \brief Functions whose first argument has type WGPUTexture.
  *
  * @{
+ */
+/**
+ * @returns
+ * This value is @ref ReturnedWithOwnership.
  */
 WGPU_EXPORT WGPUTextureView wgpuTextureCreateView(WGPUTexture texture, WGPU_NULLABLE WGPUTextureViewDescriptor const * descriptor) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuTextureDestroy(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -3439,7 +3439,6 @@ objects:
           doc: |
             Returns a mutable pointer to beginning of the mapped range.
             Returns `NULL` with @ref ImplementationDefinedLogging if:
-
             - There is any content-timeline error as defined in the WebGPU specification for `getMappedRange()` (alignments, overlaps, etc.)
             - The buffer is not mapped with @ref WGPUMapMode_Write.
           type: c_void
@@ -3461,7 +3460,6 @@ objects:
             Returns a const pointer to beginning of the mapped range.
             It must not be written; writing to this range causes undefined behavior.
             Returns `NULL` with @ref ImplementationDefinedLogging if:
-
             - There is any content-timeline error as defined in the WebGPU specification for `getMappedRange()` (alignments, overlaps, etc.)
               **except** for overlaps with other *const* ranges, which are allowed in C.
               (JS does not allow this because const ranges do not exist.)


### PR DESCRIPTION
- Require return docs to be single-paragraph

  Verified that the bullets still work even though Markdown sorta treats
them as a separate paragraph. In the generated docs the bullets now end
up inside the `<dd>` for the return value, instead of outside.
- Generate docs for `passed_with_ownership` on return types

Fixes #388