### PR TITLE
Proposal: Allow use of WGPU_BUFFER_BINDING_LAYOUT_INIT/etc for defaulting

### DIFF
--- a/doc/articles/SentinelValues.md
+++ b/doc/articles/SentinelValues.md
@@ -16,7 +16,7 @@ can be called equivalently as `b.getMappedRange()`, `b.getMappedRange(0)`,
 
 To represent `undefined` in C, `webgpu.h` uses `NULL` where possible (anything
 behind a pointer, including objects), `*_UNDEFINED` sentinel numeric values
-(generally `UINT32_MAX`, etc.) and `*_Undefined` enum values (generally `0`).
+(usually `UINT32_MAX` or similar) and `*_Undefined` enum values (usually `0`).
 
 The place that uses the type will define what to do with an undefined value.
 It may be:

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -70,6 +70,7 @@
 #define _wgpu_COMMA ,
 #if defined(__cplusplus)
 #  define _wgpu_ENUM_ZERO_INIT(type) type(0)
+#  define _wgpu_STRUCT_ZERO_INIT {}
 #  if __cplusplus >= 201103L
 #    define _wgpu_MAKE_INIT_STRUCT(type, value) (type value)
 #  else
@@ -77,6 +78,7 @@
 #  endif
 #else
 #  define _wgpu_ENUM_ZERO_INIT(type) (type)0
+#  define _wgpu_STRUCT_ZERO_INIT {0}
 #  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #    define _wgpu_MAKE_INIT_STRUCT(type, value) ((type) value)
 #  else

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -560,17 +560,25 @@ func (g *Generator) DefaultValue(member ParameterType, isDocString bool) string 
 		} else {
 			return *member.Default
 		}
+	case strings.HasPrefix(member.Type, "struct."):
+		if member.Optional {
+			return literal("NULL")
+		} else if member.Default == nil {
+			typ := strings.TrimPrefix(member.Type, "struct.")
+			return ref("WGPU_" + ConstantCase(typ) + "_INIT")
+		} else if *member.Default == "zero" {
+			if isDocString {
+				return "zero (so the entry is `BindingNotUsed`)"
+			} else {
+				return literal("{0}")
+			}
+		} else {
+			panic("unknown default for struct type")
+		}
 	case member.Default != nil:
 		panic(fmt.Errorf("type %s should not have a default", member.Type))
 
 	// Cases that should not have member.Default
-	case strings.HasPrefix(member.Type, "struct."):
-		if member.Optional {
-			return literal("NULL")
-		} else {
-			typ := strings.TrimPrefix(member.Type, "struct.")
-			return ref("WGPU_" + ConstantCase(typ) + "_INIT")
-		}
 	case strings.HasPrefix(member.Type, "callback."):
 		typ := strings.TrimPrefix(member.Type, "callback.")
 		return ref("WGPU_" + ConstantCase(typ) + "_CALLBACK_INFO_INIT")

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -568,7 +568,7 @@ func (g *Generator) DefaultValue(member ParameterType, isDocString bool) string 
 			return ref("WGPU_" + ConstantCase(typ) + "_INIT")
 		} else if *member.Default == "zero" {
 			if isDocString {
-				return "zero (so the entry is `BindingNotUsed`)"
+				return "zero (which sets the entry to `BindingNotUsed`)"
 			} else {
 				return literal("_wgpu_STRUCT_ZERO_INIT")
 			}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -570,7 +570,7 @@ func (g *Generator) DefaultValue(member ParameterType, isDocString bool) string 
 			if isDocString {
 				return "zero (so the entry is `BindingNotUsed`)"
 			} else {
-				return literal("{0}")
+				return literal("_wgpu_STRUCT_ZERO_INIT")
 			}
 		} else {
 			panic("unknown default for struct type")

--- a/schema.json
+++ b/schema.json
@@ -160,7 +160,7 @@
                         "number",
                         "boolean"
                     ],
-                    "description": "Default value assigned to this parameter when using initializer macro"
+                    "description": "Default value assigned to this parameter when using initializer macro. Special context-dependent values include constant names (`constant.*`), bitflag names (unprefixed), and `zero` for struct-zero-init (where zero-init is known to have the desired result)."
                 }
             },
             "required": [

--- a/webgpu.h
+++ b/webgpu.h
@@ -1673,6 +1673,9 @@ typedef struct WGPUBlendComponent {
 typedef struct WGPUBufferBindingLayout {
     WGPUChainedStruct const * nextInChain;
     /**
+     * If set to @ref WGPUBufferBindingType_Undefined,
+     * [defaults](@ref SentinelValues) to @ref WGPUBufferBindingType_Uniform.
+     *
      * The `INIT` macro sets this to @ref WGPUBufferBindingType_BindingNotUsed.
      */
     WGPUBufferBindingType type;
@@ -2561,6 +2564,9 @@ typedef struct WGPURequestAdapterOptions {
 typedef struct WGPUSamplerBindingLayout {
     WGPUChainedStruct const * nextInChain;
     /**
+     * If set to @ref WGPUSamplerBindingType_Undefined,
+     * [defaults](@ref SentinelValues) to @ref WGPUSamplerBindingType_Filtering.
+     *
      * The `INIT` macro sets this to @ref WGPUSamplerBindingType_BindingNotUsed.
      */
     WGPUSamplerBindingType type;
@@ -2775,6 +2781,9 @@ typedef struct WGPUStencilFaceState {
 typedef struct WGPUStorageTextureBindingLayout {
     WGPUChainedStruct const * nextInChain;
     /**
+     * If set to @ref WGPUStorageTextureAccess_Undefined,
+     * [defaults](@ref SentinelValues) to @ref WGPUStorageTextureAccess_WriteOnly.
+     *
      * The `INIT` macro sets this to @ref WGPUStorageTextureAccess_BindingNotUsed.
      */
     WGPUStorageTextureAccess access;
@@ -3245,6 +3254,9 @@ typedef struct WGPUTexelCopyBufferLayout {
 typedef struct WGPUTextureBindingLayout {
     WGPUChainedStruct const * nextInChain;
     /**
+     * If set to @ref WGPUTextureSampleType_Undefined,
+     * [defaults](@ref SentinelValues) to @ref WGPUTextureSampleType_Float.
+     *
      * The `INIT` macro sets this to @ref WGPUTextureSampleType_BindingNotUsed.
      */
     WGPUTextureSampleType sampleType;

--- a/webgpu.h
+++ b/webgpu.h
@@ -1676,7 +1676,7 @@ typedef struct WGPUBufferBindingLayout {
      * If set to @ref WGPUBufferBindingType_Undefined,
      * [defaults](@ref SentinelValues) to @ref WGPUBufferBindingType_Uniform.
      *
-     * The `INIT` macro sets this to @ref WGPUBufferBindingType_BindingNotUsed.
+     * The `INIT` macro sets this to @ref WGPUBufferBindingType_Undefined.
      */
     WGPUBufferBindingType type;
     /**
@@ -1694,7 +1694,7 @@ typedef struct WGPUBufferBindingLayout {
  */
 #define WGPU_BUFFER_BINDING_LAYOUT_INIT _wgpu_MAKE_INIT_STRUCT(WGPUBufferBindingLayout, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
-    /*.type=*/WGPUBufferBindingType_BindingNotUsed _wgpu_COMMA \
+    /*.type=*/WGPUBufferBindingType_Undefined _wgpu_COMMA \
     /*.hasDynamicOffset=*/0 _wgpu_COMMA \
     /*.minBindingSize=*/0 _wgpu_COMMA \
 })
@@ -2567,7 +2567,7 @@ typedef struct WGPUSamplerBindingLayout {
      * If set to @ref WGPUSamplerBindingType_Undefined,
      * [defaults](@ref SentinelValues) to @ref WGPUSamplerBindingType_Filtering.
      *
-     * The `INIT` macro sets this to @ref WGPUSamplerBindingType_BindingNotUsed.
+     * The `INIT` macro sets this to @ref WGPUSamplerBindingType_Undefined.
      */
     WGPUSamplerBindingType type;
 } WGPUSamplerBindingLayout WGPU_STRUCTURE_ATTRIBUTE;
@@ -2577,7 +2577,7 @@ typedef struct WGPUSamplerBindingLayout {
  */
 #define WGPU_SAMPLER_BINDING_LAYOUT_INIT _wgpu_MAKE_INIT_STRUCT(WGPUSamplerBindingLayout, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
-    /*.type=*/WGPUSamplerBindingType_BindingNotUsed _wgpu_COMMA \
+    /*.type=*/WGPUSamplerBindingType_Undefined _wgpu_COMMA \
 })
 
 /**
@@ -2784,7 +2784,7 @@ typedef struct WGPUStorageTextureBindingLayout {
      * If set to @ref WGPUStorageTextureAccess_Undefined,
      * [defaults](@ref SentinelValues) to @ref WGPUStorageTextureAccess_WriteOnly.
      *
-     * The `INIT` macro sets this to @ref WGPUStorageTextureAccess_BindingNotUsed.
+     * The `INIT` macro sets this to @ref WGPUStorageTextureAccess_Undefined.
      */
     WGPUStorageTextureAccess access;
     /**
@@ -2804,7 +2804,7 @@ typedef struct WGPUStorageTextureBindingLayout {
  */
 #define WGPU_STORAGE_TEXTURE_BINDING_LAYOUT_INIT _wgpu_MAKE_INIT_STRUCT(WGPUStorageTextureBindingLayout, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
-    /*.access=*/WGPUStorageTextureAccess_BindingNotUsed _wgpu_COMMA \
+    /*.access=*/WGPUStorageTextureAccess_Undefined _wgpu_COMMA \
     /*.format=*/WGPUTextureFormat_Undefined _wgpu_COMMA \
     /*.viewDimension=*/WGPUTextureViewDimension_Undefined _wgpu_COMMA \
 })
@@ -3257,7 +3257,7 @@ typedef struct WGPUTextureBindingLayout {
      * If set to @ref WGPUTextureSampleType_Undefined,
      * [defaults](@ref SentinelValues) to @ref WGPUTextureSampleType_Float.
      *
-     * The `INIT` macro sets this to @ref WGPUTextureSampleType_BindingNotUsed.
+     * The `INIT` macro sets this to @ref WGPUTextureSampleType_Undefined.
      */
     WGPUTextureSampleType sampleType;
     /**
@@ -3277,7 +3277,7 @@ typedef struct WGPUTextureBindingLayout {
  */
 #define WGPU_TEXTURE_BINDING_LAYOUT_INIT _wgpu_MAKE_INIT_STRUCT(WGPUTextureBindingLayout, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
-    /*.sampleType=*/WGPUTextureSampleType_BindingNotUsed _wgpu_COMMA \
+    /*.sampleType=*/WGPUTextureSampleType_Undefined _wgpu_COMMA \
     /*.viewDimension=*/WGPUTextureViewDimension_Undefined _wgpu_COMMA \
     /*.multisampled=*/0 _wgpu_COMMA \
 })
@@ -3421,19 +3421,19 @@ typedef struct WGPUBindGroupLayoutEntry {
      */
     WGPUShaderStage visibility;
     /**
-     * The `INIT` macro sets this to @ref WGPU_BUFFER_BINDING_LAYOUT_INIT.
+     * The `INIT` macro sets this to zero (so the entry is `BindingNotUsed`).
      */
     WGPUBufferBindingLayout buffer;
     /**
-     * The `INIT` macro sets this to @ref WGPU_SAMPLER_BINDING_LAYOUT_INIT.
+     * The `INIT` macro sets this to zero (so the entry is `BindingNotUsed`).
      */
     WGPUSamplerBindingLayout sampler;
     /**
-     * The `INIT` macro sets this to @ref WGPU_TEXTURE_BINDING_LAYOUT_INIT.
+     * The `INIT` macro sets this to zero (so the entry is `BindingNotUsed`).
      */
     WGPUTextureBindingLayout texture;
     /**
-     * The `INIT` macro sets this to @ref WGPU_STORAGE_TEXTURE_BINDING_LAYOUT_INIT.
+     * The `INIT` macro sets this to zero (so the entry is `BindingNotUsed`).
      */
     WGPUStorageTextureBindingLayout storageTexture;
 } WGPUBindGroupLayoutEntry WGPU_STRUCTURE_ATTRIBUTE;
@@ -3445,10 +3445,10 @@ typedef struct WGPUBindGroupLayoutEntry {
     /*.nextInChain=*/NULL _wgpu_COMMA \
     /*.binding=*/0 _wgpu_COMMA \
     /*.visibility=*/WGPUShaderStage_None _wgpu_COMMA \
-    /*.buffer=*/WGPU_BUFFER_BINDING_LAYOUT_INIT _wgpu_COMMA \
-    /*.sampler=*/WGPU_SAMPLER_BINDING_LAYOUT_INIT _wgpu_COMMA \
-    /*.texture=*/WGPU_TEXTURE_BINDING_LAYOUT_INIT _wgpu_COMMA \
-    /*.storageTexture=*/WGPU_STORAGE_TEXTURE_BINDING_LAYOUT_INIT _wgpu_COMMA \
+    /*.buffer=*/{0} _wgpu_COMMA \
+    /*.sampler=*/{0} _wgpu_COMMA \
+    /*.texture=*/{0} _wgpu_COMMA \
+    /*.storageTexture=*/{0} _wgpu_COMMA \
 })
 
 /**

--- a/webgpu.h
+++ b/webgpu.h
@@ -59,6 +59,7 @@
 #define _wgpu_COMMA ,
 #if defined(__cplusplus)
 #  define _wgpu_ENUM_ZERO_INIT(type) type(0)
+#  define _wgpu_STRUCT_ZERO_INIT {}
 #  if __cplusplus >= 201103L
 #    define _wgpu_MAKE_INIT_STRUCT(type, value) (type value)
 #  else
@@ -66,6 +67,7 @@
 #  endif
 #else
 #  define _wgpu_ENUM_ZERO_INIT(type) (type)0
+#  define _wgpu_STRUCT_ZERO_INIT {0}
 #  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #    define _wgpu_MAKE_INIT_STRUCT(type, value) ((type) value)
 #  else
@@ -3445,10 +3447,10 @@ typedef struct WGPUBindGroupLayoutEntry {
     /*.nextInChain=*/NULL _wgpu_COMMA \
     /*.binding=*/0 _wgpu_COMMA \
     /*.visibility=*/WGPUShaderStage_None _wgpu_COMMA \
-    /*.buffer=*/{0} _wgpu_COMMA \
-    /*.sampler=*/{0} _wgpu_COMMA \
-    /*.texture=*/{0} _wgpu_COMMA \
-    /*.storageTexture=*/{0} _wgpu_COMMA \
+    /*.buffer=*/_wgpu_STRUCT_ZERO_INIT _wgpu_COMMA \
+    /*.sampler=*/_wgpu_STRUCT_ZERO_INIT _wgpu_COMMA \
+    /*.texture=*/_wgpu_STRUCT_ZERO_INIT _wgpu_COMMA \
+    /*.storageTexture=*/_wgpu_STRUCT_ZERO_INIT _wgpu_COMMA \
 })
 
 /**

--- a/webgpu.h
+++ b/webgpu.h
@@ -3423,19 +3423,19 @@ typedef struct WGPUBindGroupLayoutEntry {
      */
     WGPUShaderStage visibility;
     /**
-     * The `INIT` macro sets this to zero (so the entry is `BindingNotUsed`).
+     * The `INIT` macro sets this to zero (which sets the entry to `BindingNotUsed`).
      */
     WGPUBufferBindingLayout buffer;
     /**
-     * The `INIT` macro sets this to zero (so the entry is `BindingNotUsed`).
+     * The `INIT` macro sets this to zero (which sets the entry to `BindingNotUsed`).
      */
     WGPUSamplerBindingLayout sampler;
     /**
-     * The `INIT` macro sets this to zero (so the entry is `BindingNotUsed`).
+     * The `INIT` macro sets this to zero (which sets the entry to `BindingNotUsed`).
      */
     WGPUTextureBindingLayout texture;
     /**
-     * The `INIT` macro sets this to zero (so the entry is `BindingNotUsed`).
+     * The `INIT` macro sets this to zero (which sets the entry to `BindingNotUsed`).
      */
     WGPUStorageTextureBindingLayout storageTexture;
 } WGPUBindGroupLayoutEntry WGPU_STRUCTURE_ATTRIBUTE;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1670,7 +1670,8 @@ structs:
     members:
       - name: type
         doc: |
-          TODO
+          If set to @ref WGPUBufferBindingType_Undefined,
+          [defaults](@ref SentinelValues) to @ref WGPUBufferBindingType_Uniform.
         type: enum.buffer_binding_type
         default: binding_not_used
       - name: has_dynamic_offset
@@ -2569,7 +2570,8 @@ structs:
     members:
       - name: type
         doc: |
-          TODO
+          If set to @ref WGPUSamplerBindingType_Undefined,
+          [defaults](@ref SentinelValues) to @ref WGPUSamplerBindingType_Filtering.
         type: enum.sampler_binding_type
         default: binding_not_used
   - name: sampler_descriptor
@@ -2700,7 +2702,8 @@ structs:
     members:
       - name: access
         doc: |
-          TODO
+          If set to @ref WGPUStorageTextureAccess_Undefined,
+          [defaults](@ref SentinelValues) to @ref WGPUStorageTextureAccess_WriteOnly.
         type: enum.storage_texture_access
         default: binding_not_used
       - name: format
@@ -2962,7 +2965,8 @@ structs:
     members:
       - name: sample_type
         doc: |
-          TODO
+          If set to @ref WGPUTextureSampleType_Undefined,
+          [defaults](@ref SentinelValues) to @ref WGPUTextureSampleType_Float.
         type: enum.texture_sample_type
         default: binding_not_used
       - name: view_dimension

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1618,21 +1618,33 @@ structs:
         doc: |
           TODO
         type: struct.buffer_binding_layout
+        # Use struct-zero-init here to get .type=BindingNotUsed (0), instead of
+        # Undefined which is the default in WGPU_BUFFER_BINDING_LAYOUT_INIT.
+        # Zero-init is conveniently correct for the rest of the fields, too.
         default: zero
       - name: sampler
         doc: |
           TODO
         type: struct.sampler_binding_layout
+        # Use struct-zero-init here to get .type=BindingNotUsed (0), instead of
+        # Undefined which is the default in WGPU_SAMPLER_BINDING_LAYOUT_INIT.
+        # Zero-init is conveniently correct for the rest of the fields, too.
         default: zero
       - name: texture
         doc: |
           TODO
         type: struct.texture_binding_layout
+        # Use struct-zero-init here to get .sampleType=BindingNotUsed (0), instead of
+        # Undefined which is the default in WGPU_TEXTURE_BINDING_LAYOUT_INIT.
+        # Zero-init is conveniently correct for the rest of the fields, too.
         default: zero
       - name: storage_texture
         doc: |
           TODO
         type: struct.storage_texture_binding_layout
+        # Use struct-zero-init here to get .access=BindingNotUsed (0), instead of
+        # Undefined which is the default in WGPU_STORAGE_TEXTURE_BINDING_LAYOUT_INIT.
+        # Zero-init is conveniently correct for the rest of the fields, too.
         default: zero
   - name: blend_component
     doc: |

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1618,18 +1618,22 @@ structs:
         doc: |
           TODO
         type: struct.buffer_binding_layout
+        default: zero
       - name: sampler
         doc: |
           TODO
         type: struct.sampler_binding_layout
+        default: zero
       - name: texture
         doc: |
           TODO
         type: struct.texture_binding_layout
+        default: zero
       - name: storage_texture
         doc: |
           TODO
         type: struct.storage_texture_binding_layout
+        default: zero
   - name: blend_component
     doc: |
       TODO
@@ -1673,7 +1677,7 @@ structs:
           If set to @ref WGPUBufferBindingType_Undefined,
           [defaults](@ref SentinelValues) to @ref WGPUBufferBindingType_Uniform.
         type: enum.buffer_binding_type
-        default: binding_not_used
+        default: undefined
       - name: has_dynamic_offset
         doc: |
           TODO
@@ -2573,7 +2577,7 @@ structs:
           If set to @ref WGPUSamplerBindingType_Undefined,
           [defaults](@ref SentinelValues) to @ref WGPUSamplerBindingType_Filtering.
         type: enum.sampler_binding_type
-        default: binding_not_used
+        default: undefined
   - name: sampler_descriptor
     doc: |
       TODO
@@ -2705,7 +2709,7 @@ structs:
           If set to @ref WGPUStorageTextureAccess_Undefined,
           [defaults](@ref SentinelValues) to @ref WGPUStorageTextureAccess_WriteOnly.
         type: enum.storage_texture_access
-        default: binding_not_used
+        default: undefined
       - name: format
         doc: |
           TODO
@@ -2968,7 +2972,7 @@ structs:
           If set to @ref WGPUTextureSampleType_Undefined,
           [defaults](@ref SentinelValues) to @ref WGPUTextureSampleType_Float.
         type: enum.texture_sample_type
-        default: binding_not_used
+        default: undefined
       - name: view_dimension
         doc: |
           [Defaults](@ref SentinelValues) to @ref WGPUTextureViewDimension_2D.


### PR DESCRIPTION
An alternative to PR #424. (This proposal prevents us from removing `Undefined` from the binding type enums, which that PR did.)

This moves the defaulting to `BindingNotUsed` out to `WGPU_BIND_GROUP_LAYOUT_ENTRY_INIT` so that it still generates a `WGPUBindGroupLayoutEntry` with no bindings set, but changes
`WGPU_BUFFER_BINDING_LAYOUT_INIT`
`WGPU_SAMPLER_BINDING_LAYOUT_INIT`
`WGPU_TEXTURE_BINDING_LAYOUT_INIT`
`WGPU_STORAGE_TEXTURE_BINDING_LAYOUT_INIT`
so that _they_ set their respective types to `Undefined` instead of `BindingNotUsed`.

There honestly isn't _that much_ value in this in C, but it is more consistent with JS and should work better for higher-level language bindings. These examples all resolve to
`{ binding, visibility, buffer: { type: "uniform", hasDynamicOffset: false, minBindingSize: 0 } }`:

In JS:
```js
const entry = { binding, visibility, buffer = {} };
```

In C:
```c
WGPUBindGroupLayoutEntry entry = WGPU_BIND_GROUP_LAYOUT_ENTRY_INIT;
entry.binding = binding;
entry.visibility = visibility;
entry.buffer = WGPU_BUFFER_BINDING_LAYOUT_INIT;
// or
WGPUBindGroupLayoutEntry entry = {
  .binding = 0,
  .visibility = visibility,
  .buffer = WGPU_BUFFER_BINDING_LAYOUT_INIT,
  // other fields should get zero-initialized I think, which if so is what we want
};
```

In C++, something like:
```cpp
wgpu::BindGroupLayoutEntry entry{
  .binding = 0,
  .visibility = visibility,
  .buffer = {},
  // note that unlike in C, gcc/clang with -Wextra do warn on missing fields in designated initializers
};
```