### PR TITLE
State that webgpu.h has the same behavior as the JS spec

### DIFF
--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -9,6 +9,12 @@
  *
  * This is the home of WebGPU C API specification. We define here the standard
  * `webgpu.h` header that all implementations should provide.
+ *
+ * For all details where behavior is not otherwise specified, `webgpu.h` has
+ * the same behavior as the WebGPU specification for JavaScript on the Web.
+ * The WebIDL-based Web specification is mapped into C as faithfully (and
+ * bidirectionally) as practical/possible.
+ * The working draft of WebGPU can be found at <https://www.w3.org/TR/webgpu/>.
  */
 
 #ifndef {{.HeaderName | ConstantCase}}_H_

--- a/webgpu.h
+++ b/webgpu.h
@@ -13,6 +13,12 @@
  *
  * This is the home of WebGPU C API specification. We define here the standard
  * `webgpu.h` header that all implementations should provide.
+ *
+ * For all details where behavior is not otherwise specified, `webgpu.h` has
+ * the same behavior as the WebGPU specification for JavaScript on the Web.
+ * The WebIDL-based Web specification is mapped into C as faithfully (and
+ * bidirectionally) as practical/possible.
+ * The working draft of WebGPU can be found at <https://www.w3.org/TR/webgpu/>.
  */
 
 #ifndef WEBGPU_H_


### PR DESCRIPTION
This (sorta) fixes the last documentation item that was tracked in #25, which I just updated.

Actually I won't link this to #25 just yet because I'm sure it would be a good idea to write an actual article about how things get translated in general, but I'm going to call that non-critical