### PR TITLE
Fix inconsistent management of ExtSuffix in INIT macros

### DIFF
--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -306,7 +306,7 @@ typedef struct WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}} {
 /**
  * Initializer for @ref WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}}.
  */
-#define WGPU_{{.Name | ConstantCase}}_CALLBACK_INFO{{$.ExtSuffix}}_INIT _wgpu_MAKE_INIT_STRUCT(WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}}, { \
+#define WGPU_{{.Name | ConstantCase}}_CALLBACK_INFO{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}}_INIT _wgpu_MAKE_INIT_STRUCT(WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}}, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
 {{-   if eq .Style "callback_mode" }}
     /*.mode=*/WGPUCallbackMode_WaitAnyOnly _wgpu_COMMA \

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -569,11 +569,11 @@ func (g *Generator) DefaultValue(member ParameterType, isDocString bool) string 
 			return literal("NULL")
 		} else {
 			typ := strings.TrimPrefix(member.Type, "struct.")
-			return ref("WGPU_" + ConstantCase(typ) + "_INIT")
+			return ref("WGPU_" + ConstantCase(typ) + g.ConstantExtSuffix() + "_INIT")
 		}
 	case strings.HasPrefix(member.Type, "callback."):
 		typ := strings.TrimPrefix(member.Type, "callback.")
-		return ref("WGPU_" + ConstantCase(typ) + "_CALLBACK_INFO_INIT")
+		return ref("WGPU_" + ConstantCase(typ) + "_CALLBACK_INFO" + g.ConstantExtSuffix() + "_INIT")
 	case strings.HasPrefix(member.Type, "object."):
 		return literal("NULL")
 	case strings.HasPrefix(member.Type, "array<"):
@@ -584,5 +584,13 @@ func (g *Generator) DefaultValue(member ParameterType, isDocString bool) string 
 		return literal("NULL")
 	default:
 		panic("invalid prefix: " + member.Type + " in member " + member.Name)
+	}
+}
+
+func (g *Generator) ConstantExtSuffix() string {
+	if g.ExtSuffix != "" {
+		return "_" + ConstantCase(g.ExtSuffix)
+	} else {
+		return ""
 	}
 }


### PR DESCRIPTION
Proper handling of ExtSuffix was missing from in #422 (could be listed in the followup issue #427).

Note that this does not account for potential `namespace`, because I am not sure how we should handle it: if a member from a struct `foo` has type to `struct.bar`, can we be sure that there is a single `bar` entry and use its namespace, or should we look for `bar` first in the same namespace as `foo`, then fallback to default namespace?

SIde note: neither ExtSuffix not namespaces are tested, we could have a minimal extension example in `test`.