### PR TITLE
Move mainpage documentation to yml file

### DIFF
--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -1,21 +1,7 @@
 {{- MCommentN .Copyright 0}}
 
 /** @file */
-
-/**
- * \mainpage
- *
- * **Important:** *This documentation is a Work In Progress.*
- *
- * This is the home of WebGPU C API specification. We define here the standard
- * `webgpu.h` header that all implementations should provide.
- *
- * For all details where behavior is not otherwise specified, `webgpu.h` has
- * the same behavior as the WebGPU specification for JavaScript on the Web.
- * The WebIDL-based Web specification is mapped into C as faithfully (and
- * bidirectionally) as practical/possible.
- * The working draft of WebGPU can be found at <https://www.w3.org/TR/webgpu/>.
- */
+{{MComment (print "\\mainpage\n" .Doc) 0}}
 
 #ifndef {{.HeaderName | ConstantCase}}_H_
 #define {{.HeaderName | ConstantCase}}_H_

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -1,7 +1,7 @@
 {{- MCommentN .Copyright 0}}
 
 /** @file */
-{{MComment (print "\\mainpage\n" .Doc) 0}}
+{{MCommentMainPage .Doc 0}}
 
 #ifndef {{.HeaderName | ConstantCase}}_H_
 #define {{.HeaderName | ConstantCase}}_H_

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -24,6 +24,12 @@ func (g *Generator) Gen(dst io.Writer) error {
 			"MComment":  func(v string, indent int) string { return Comment(v, CommentTypeMultiLine, indent, true) },
 			"SCommentN": func(v string, indent int) string { return Comment(v, CommentTypeSingleLine, indent, false) },
 			"MCommentN": func(v string, indent int) string { return Comment(v, CommentTypeMultiLine, indent, false) },
+			"MCommentMainPage": func(v string, indent int) string {
+				if v == "" || strings.TrimSpace(v) == "TODO" {
+					return ""
+				}
+				return Comment("\\mainpage\n\n"+strings.TrimSpace(v), CommentTypeMultiLine, indent, true)
+			},
 			"MCommentEnum": func(v string, indent int, prefix string, e Enum, entryIndex int) string {
 				if v == "" || strings.TrimSpace(v) == "TODO" {
 					return ""

--- a/gen/yml.go
+++ b/gen/yml.go
@@ -10,6 +10,7 @@ import (
 type Yml struct {
 	Copyright  string `yaml:"copyright"`
 	Name       string `yaml:"name"`
+	Doc        string `yaml:"doc"`
 	EnumPrefix string `yaml:"enum_prefix"`
 
 	Constants []Constant `yaml:"constants"`

--- a/schema.json
+++ b/schema.json
@@ -256,6 +256,9 @@
             "pattern": "^0x[0-9]{4}$",
             "description": "The dedicated enum prefix for the implementation specific header to avoid collisions"
         },
+        "doc": {
+            "type": "string"
+        },
         "typedefs": {
             "type": "array",
             "items": {
@@ -516,6 +519,7 @@
         "copyright",
         "name",
         "enum_prefix",
+        "doc",
         "constants",
         "typedefs",
         "enums",

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -6,10 +6,10 @@ name: webgpu
 enum_prefix: '0x0000'
 doc: |
   **Important:** *This documentation is a Work In Progress.*
-  
+
   This is the home of WebGPU C API specification. We define here the standard
   `webgpu.h` header that all implementations should provide.
-  
+
   For all details where behavior is not otherwise specified, `webgpu.h` has
   the same behavior as the WebGPU specification for JavaScript on the Web.
   The WebIDL-based Web specification is mapped into C as faithfully (and
@@ -708,8 +708,9 @@ enums:
       - name: render_pass_max_draw_count
         doc: |
           TODO
-      # TODO(#214): Move all of the surface sources into block 0x0001
       - name: surface_source_metal_layer
+        # TODO(#214): Move all of the surface sources into block 0x0001
+
         doc: |
           TODO
       - name: surface_source_windows_HWND

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -708,9 +708,8 @@ enums:
       - name: render_pass_max_draw_count
         doc: |
           TODO
+      # TODO(#214): Move all of the surface sources into block 0x0001
       - name: surface_source_metal_layer
-        # TODO(#214): Move all of the surface sources into block 0x0001
-
         doc: |
           TODO
       - name: surface_source_windows_HWND

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -4,6 +4,17 @@ copyright: |
   SPDX-License-Identifier: BSD-3-Clause
 name: webgpu
 enum_prefix: '0x0000'
+doc: |
+  **Important:** *This documentation is a Work In Progress.*
+  
+  This is the home of WebGPU C API specification. We define here the standard
+  `webgpu.h` header that all implementations should provide.
+  
+  For all details where behavior is not otherwise specified, `webgpu.h` has
+  the same behavior as the WebGPU specification for JavaScript on the Web.
+  The WebIDL-based Web specification is mapped into C as faithfully (and
+  bidirectionally) as practical/possible.
+  The working draft of WebGPU can be found at <https://www.w3.org/TR/webgpu/>.
 constants:
   - name: array_layer_count_undefined
     value: uint32_max


### PR DESCRIPTION
As I was starting to play around with the generation of header files for custom extensions, I felt the need to have this mainpage comment be driven by the yaml spec file rather than hardcoded in the template!