### PR TITLE
Use 0.0f/0.0f instead of math.h NAN

### DIFF
--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -67,7 +67,6 @@
 {{- if eq .Name "webgpu"}}
 #include <stdint.h>
 #include <stddef.h>
-#include <math.h>
 {{else}}
 #include "webgpu.h"
 {{end}}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -196,7 +196,7 @@ func (g *Generator) CValue(s string) (string, error) {
 	case "uint64_max":
 		return "UINT64_MAX", nil
 	case "nan":
-		return "NAN", nil
+		return "0.0f / 0.0f", nil
 	default:
 		var num string
 		var base int

--- a/webgpu.h
+++ b/webgpu.h
@@ -60,7 +60,6 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <math.h>
 
 #define _wgpu_COMMA ,
 #if defined(__cplusplus)
@@ -92,7 +91,7 @@
  * Value to be assigned to member depthClearValue of @ref WGPURenderPassDepthStencilAttachment
  * to mean that it is not defined.
  */
-#define WGPU_DEPTH_CLEAR_VALUE_UNDEFINED (NAN)
+#define WGPU_DEPTH_CLEAR_VALUE_UNDEFINED (0.0f / 0.0f)
 #define WGPU_DEPTH_SLICE_UNDEFINED (UINT32_MAX)
 #define WGPU_LIMIT_U32_UNDEFINED (UINT32_MAX)
 #define WGPU_LIMIT_U64_UNDEFINED (UINT64_MAX)


### PR DESCRIPTION
IEEE754-2008 says it produces a quiet NaN, so as long as the system has IEEE754 math this is fine.
OTOH if the system doesn't have NAN then `math.h` won't define it so this would produce a compilation error.

It compiles fine on Clang and GCC but MSVC does have a warning:
```
error C2124: divide or mod by zero
```

The only reason to do this is to avoid including `math.h`. So I think the MSVC warning is enough reason to not make this change (just to make the header as warning-clean as possible, especially since this is in a macro currently).

Issue: #427