### PR TITLE
Remove GetCurrentTextureStatus_OutOfMemory

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -863,14 +863,9 @@ typedef enum WGPUSurfaceGetCurrentTextureStatus {
     WGPUSurfaceGetCurrentTextureStatus_Lost = 0x00000005,
     /**
      * `0x00000006`.
-     * The system ran out of memory.
-     */
-    WGPUSurfaceGetCurrentTextureStatus_OutOfMemory = 0x00000006,
-    /**
-     * `0x00000007`.
      * The surface is not configured, or there was an @ref OutStructChainError.
      */
-    WGPUSurfaceGetCurrentTextureStatus_Error = 0x00000007,
+    WGPUSurfaceGetCurrentTextureStatus_Error = 0x00000006,
     WGPUSurfaceGetCurrentTextureStatus_Force32 = 0x7FFFFFFF
 } WGPUSurfaceGetCurrentTextureStatus WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -823,8 +823,6 @@ enums:
         doc: The surface is too different to be used, compared to when it was originally created.
       - name: lost
         doc: The connection to whatever owns the surface was lost.
-      - name: out_of_memory
-        doc: The system ran out of memory.
       - name: error
         doc: The surface is not configured, or there was an @ref OutStructChainError.
   - name: texture_aspect


### PR DESCRIPTION
This doesn't seem super likely to be handleable distinctly from Lost (surface loss) or losing the device, but if it is, the implementation (wgpu-native) can expose it as an extension. It isn't used in JS or Dawn.

> - LK: Could maybe return a message string? (Though requires a FreeMembers, or a static string.)
> - (... we didn't really discuss this much but I think we thought it wasn't worth it)

@lokokung to confirm because I forgot to take notes

Issue: #401