### PR TITLE
Add storage limits for Compat

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -2034,7 +2034,23 @@ typedef struct WGPULimits {
     /**
      * The `INIT` macro sets this to @ref WGPU_LIMIT_U32_UNDEFINED.
      */
+    uint32_t maxStorageBuffersInVertexStage;
+    /**
+     * The `INIT` macro sets this to @ref WGPU_LIMIT_U32_UNDEFINED.
+     */
+    uint32_t maxStorageBuffersInFragmentStage;
+    /**
+     * The `INIT` macro sets this to @ref WGPU_LIMIT_U32_UNDEFINED.
+     */
     uint32_t maxStorageTexturesPerShaderStage;
+    /**
+     * The `INIT` macro sets this to @ref WGPU_LIMIT_U32_UNDEFINED.
+     */
+    uint32_t maxStorageTexturesInVertexStage;
+    /**
+     * The `INIT` macro sets this to @ref WGPU_LIMIT_U32_UNDEFINED.
+     */
+    uint32_t maxStorageTexturesInFragmentStage;
     /**
      * The `INIT` macro sets this to @ref WGPU_LIMIT_U32_UNDEFINED.
      */
@@ -2126,7 +2142,11 @@ typedef struct WGPULimits {
     /*.maxSampledTexturesPerShaderStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxSamplersPerShaderStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxStorageBuffersPerShaderStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
+    /*.maxStorageBuffersInVertexStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
+    /*.maxStorageBuffersInFragmentStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxStorageTexturesPerShaderStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
+    /*.maxStorageTexturesInVertexStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
+    /*.maxStorageTexturesInFragmentStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxUniformBuffersPerShaderStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxUniformBufferBindingSize=*/WGPU_LIMIT_U64_UNDEFINED _wgpu_COMMA \
     /*.maxStorageBufferBindingSize=*/WGPU_LIMIT_U64_UNDEFINED _wgpu_COMMA \

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -2142,7 +2142,27 @@ structs:
           TODO
         type: uint32
         default: constant.limit_u32_undefined
+      - name: max_storage_buffers_in_vertex_stage
+        doc: |
+          TODO
+        type: uint32
+        default: constant.limit_u32_undefined
+      - name: max_storage_buffers_in_fragment_stage
+        doc: |
+          TODO
+        type: uint32
+        default: constant.limit_u32_undefined
       - name: max_storage_textures_per_shader_stage
+        doc: |
+          TODO
+        type: uint32
+        default: constant.limit_u32_undefined
+      - name: max_storage_textures_in_vertex_stage
+        doc: |
+          TODO
+        type: uint32
+        default: constant.limit_u32_undefined
+      - name: max_storage_textures_in_fragment_stage
         doc: |
           TODO
         type: uint32


### PR DESCRIPTION
I think we're reasonably confident that these will be the correct spellings. Hopefully this is all of the limits we add for compat but even if not, better to have them in now than later.

Note these limits will be part of the core JS spec, because they can't be safely removed from JS (even when compat doesn't exist and they won't do anything).

Issue: #470