### PR TITLE
Disallow GetConstMappedRange overlaps on Wasm

### DIFF
--- a/doc/articles/BufferMapping.md
+++ b/doc/articles/BufferMapping.md
@@ -6,8 +6,8 @@
 
 - Return `NULL` with @ref ImplementationDefinedLogging if:
     - There is any content-timeline error, as defined in the WebGPU specification for `getMappedRange()` (buffer is not mapped, alignment constraints, overlaps, etc.)
-        - **Except** for overlaps between *const* ranges, which are allowed in C.
-            (JS does not allow this because const ranges do not exist.)
+        - **Except** for overlaps between *const* ranges, which are allowed in C *in non-Wasm targets only*.
+            (Wasm does not allow this because const ranges do not exist in JS.)
     - @ref wgpuBufferGetMappedRange is called, but the buffer is not mapped with @ref WGPUMapMode_Write.
 - Do not guarantee they will return any particular address value relative to another GetMappedRange call.
 - Guarantee that the mapped pointer will be aligned to 16 bytes if the `MapAsync` and `GetMappedRange` offsets are also aligned to 16 bytes.


### PR DESCRIPTION
It's not possible to allow overlapping const ranges in `wgpuBufferGetConstMappedRange()` on Wasm, because it's backed by `GPUBuffer.getMappedRange()` which doesn't allow overlaps. Technically it can be done by reserving Wasm heap memory for the whole `mapAsync()` region, instead of just memory for each `getMappedRange()` call, but this potentially uses a lot of unnecessary memory.

Another option would be to disallow these in native (non-Wasm) as well. As far as I can tell we've only ever briefly touched on whether we should have a behavior difference here, but it seems we intended to have one.

Finally, in theory we may be able to lift this in the future - if we gain the ability to make mapped GPU buffers accessible read-only directly from Wasm[^1], then we don't need to actually allocate the extra memory mentioned above. And since these are read-only mappings, it doesn't cause over-invalidation of memory.

[^1]: Requires Wasm read-only `mmap` or a way to have temporary read-only additional `Memory`s, _and_ a way to get read-only ArrayBuffers when mapping buffers.

Issue: #64, also mentioned in https://github.com/webgpu-native/webgpu-headers/issues/194#issuecomment-1612195135