### PR TITLE
GetMappedRange is safe to call anytime

### DIFF
--- a/doc/articles/Asynchronous Operations.md
+++ b/doc/articles/Asynchronous Operations.md
@@ -80,7 +80,7 @@ There are three cases of async/callback re-entrancy:
     - This does not introduce any unsafety. Implementations are required to exit critical sections before invoking callbacks.
     - This includes making nested calls to @ref wgpuInstanceWaitAny() and @ref wgpuInstanceProcessEvents(). (However, beware of overflowing the call stack!)
 - Calls to the API are nested inside @ref WGPUCallbackMode_AllowSpontaneous callbacks, which may happen at any time (during a `webgpu.h` function call or on an arbitrary thread).
-    - Therefore, calls to the API should never be made in @ref WGPUCallbackMode_AllowSpontaneous callbacks, except where otherwise noted, due to the possibility of self-deadlock.
+    - Therefore, calls to the API should never be made in @ref WGPUCallbackMode_AllowSpontaneous callbacks, except where otherwise noted (e.g. @ref wgpuBufferGetMappedRange), due to the possibility of self-deadlock.
       Additionally, applications should take extra care even when accessing their *own* state (and locks) inside the callback.
     - This includes @ref WGPUDeviceDescriptor::uncapturedErrorCallbackInfo, which is always allowed to fire spontaneously.
 - Two threads are doing things in parallel, so calls to the API are made while callbacks (or API functions in general) are running on another thread.

--- a/schema.json
+++ b/schema.json
@@ -208,7 +208,7 @@
                         "doc": {
                             "type": "string",
                             "$comment": "Doxygen doesn't support multi-paragraph return docs (containing \\n\\n)",
-                            "pattern": "^\n?.+(\n.+)*\n?$"
+                            "pattern": "^$|^\n?.+(\n.+)*\n?$"
                         },
                         "type": {
                             "$ref": "#/definitions/Type",

--- a/webgpu.h
+++ b/webgpu.h
@@ -5532,29 +5532,29 @@ WGPU_EXPORT void wgpuBindGroupLayoutRelease(WGPUBindGroupLayout bindGroupLayout)
  */
 WGPU_EXPORT void wgpuBufferDestroy(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 /**
+ * Returns a const pointer to beginning of the mapped range.
+ * It must not be written; writing to this range causes undefined behavior.
+ * See @ref GetMappedRangeBehavior for error conditions and guarantees.
+ * This function is safe to call inside spontaneous callbacks (see @ref CallbackReentrancy).
+ *
  * @param offset
  * Byte offset relative to the beginning of the buffer.
  *
  * @param size
  * Byte size of the range to get. The returned pointer is valid for exactly this many bytes.
- *
- * @returns
- * Returns a const pointer to beginning of the mapped range.
- * It must not be written; writing to this range causes undefined behavior.
- * See @ref GetMappedRangeBehavior for error conditions and guarantees.
  */
 WGPU_EXPORT void const * wgpuBufferGetConstMappedRange(WGPUBuffer buffer, size_t offset, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBufferMapState wgpuBufferGetMapState(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 /**
+ * Returns a mutable pointer to beginning of the mapped range.
+ * See @ref GetMappedRangeBehavior for error conditions and guarantees.
+ * This function is safe to call inside spontaneous callbacks (see @ref CallbackReentrancy).
+ *
  * @param offset
  * Byte offset relative to the beginning of the buffer.
  *
  * @param size
  * Byte size of the range to get. The returned pointer is valid for exactly this many bytes.
- *
- * @returns
- * Returns a mutable pointer to beginning of the mapped range.
- * See @ref GetMappedRangeBehavior for error conditions and guarantees.
  */
 WGPU_EXPORT void * wgpuBufferGetMappedRange(WGPUBuffer buffer, size_t offset, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT uint64_t wgpuBufferGetSize(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -3549,11 +3549,11 @@ objects:
             type: usize
       - name: get_mapped_range
         doc: |
-          TODO
+          Returns a mutable pointer to beginning of the mapped range.
+          See @ref GetMappedRangeBehavior for error conditions and guarantees.
+          This function is safe to call inside spontaneous callbacks (see @ref CallbackReentrancy).
         returns:
-          doc: |
-            Returns a mutable pointer to beginning of the mapped range.
-            See @ref GetMappedRangeBehavior for error conditions and guarantees.
+          doc: ""
           type: c_void
           pointer: mutable
         args:
@@ -3567,12 +3567,12 @@ objects:
             type: usize
       - name: get_const_mapped_range
         doc: |
-          TODO
+          Returns a const pointer to beginning of the mapped range.
+          It must not be written; writing to this range causes undefined behavior.
+          See @ref GetMappedRangeBehavior for error conditions and guarantees.
+          This function is safe to call inside spontaneous callbacks (see @ref CallbackReentrancy).
         returns:
-          doc: |
-            Returns a const pointer to beginning of the mapped range.
-            It must not be written; writing to this range causes undefined behavior.
-            See @ref GetMappedRangeBehavior for error conditions and guarantees.
+          doc: ""
           type: c_void
           pointer: immutable
         args:


### PR DESCRIPTION
I think we can guarantee this.

From https://github.com/webgpu-native/webgpu-headers/pull/481#discussion_r1899665893:

> @lokokung:
> Do you think "always unsafe" would be too pessimistic? I'm wondering if we could say "potentially unsafe"? (Mainly I'm thinking about `getMappedRange` calls in `MapAsync` callback which would be nice to use in spontaneous mode)

> @kainino0x:
> I prefer "always unsafe" to avoid tempting too much questioning of _when_ it's safe. That said, am I remembering correctly that it's never really _unsafe_, it's just that it can cause a self-deadlock if it tries to take a lock that's already held on the same thread?
> 
> Also, for GetMappedRange maybe we could specifically document that it's safe to call in any callback (or at least in `BufferMap` and `OnSubmittedWorkDone`). That would require the implementation to guarantee either of the following:
> 
> * said callbacks won't called spontaneously while holding any lock that GetMappedRange needs
> * GetMappedRange doesn't take any locks (it probably doesn't need them, it just needs an atomic [wrapped around the nullable mapping base pointer])