### PR TITLE
Simplify WGPUWaitStatus "Unsupported" cases

### DIFF
--- a/doc/articles/Asynchronous Operations.md
+++ b/doc/articles/Asynchronous Operations.md
@@ -41,7 +41,7 @@ The `callback` function pointer is called when the application _observes complet
 
 Waits on any WGPUFuture in the list of `futures` to complete for `timeoutNS` nanoseconds. Returns when at least one `WGPUFuture` is completed or `timeoutNS` elapses, whichever is first. If `timeoutNS` is zero, all `futures` are polled once, without blocking.
 
-- Returns @ref WGPUWaitStatus_Success if at least one `WGPUFuture` completes. Each future which _just_ completed has its respective callback fired. Each future which _is_ complete has its corresponding @ref WGPUFutureWaitInfo::completed is set to true.
+- Returns @ref WGPUWaitStatus_Success if at least one `WGPUFuture` completes. Each future which _just_ completed has its respective callback fired. Each future which _is_ complete has its corresponding @ref WGPUFutureWaitInfo::completed set to true.
     - Note that the timeout applies only to the "wait" phase, and does not affect the callback firing phase.
 - Returns @ref WGPUWaitStatus_TimedOut if the timeout passed without any futures completing.
 - Returns @ref WGPUWaitStatus_Error if the call was invalid for any of the following reasons:

--- a/doc/articles/Asynchronous Operations.md
+++ b/doc/articles/Asynchronous Operations.md
@@ -42,12 +42,12 @@ The `callback` function pointer is called when the application _observes complet
 Waits on any WGPUFuture in the list of `futures` to complete for `timeoutNS` nanoseconds. Returns when at least one `WGPUFuture` is completed or `timeoutNS` elapses, whichever is first. If `timeoutNS` is zero, all `futures` are polled once, without blocking.
 
 - Returns @ref WGPUWaitStatus_Success if at least one `WGPUFuture` completes. Each future which _just_ completed has its respective callback fired. Each future which _is_ complete has its corresponding @ref WGPUFutureWaitInfo::completed is set to true.
-  - Note that the timeout applies only to the "wait" phase, and does not affect the callback firing phase.
+    - Note that the timeout applies only to the "wait" phase, and does not affect the callback firing phase.
 - Returns @ref WGPUWaitStatus_TimedOut if the timeout passed without any futures completing.
 - Returns @ref WGPUWaitStatus_Error if the call was invalid for any of the following reasons:
-  - A @ref Timed-Wait was performed when WGPUInstanceFeatures::timedWaitAnyEnable is not enabled.
-  - The number of futures waited on in a @ref Timed-Wait is greater than the enabled WGPUInstanceFeatures::timedWaitAnyMaxCount.
-  - A wait was attempted with @ref Mixed-Sources.
+    - A @ref Timed-Wait was performed when WGPUInstanceFeatures::timedWaitAnyEnable is not enabled.
+    - The number of futures waited on in a @ref Timed-Wait is greater than the enabled WGPUInstanceFeatures::timedWaitAnyMaxCount.
+    - A wait was attempted with @ref Mixed-Sources.
 
 ### Timed Wait {#Timed-Wait}
 
@@ -58,16 +58,18 @@ Use of _timed waits_ (`timeoutNS > 0`), must be enabled on the WGPUInstance in @
 Asynchronous operations may originate from different sources. There are CPU-timeline operations and there are Queue-timeline operations. Within a _timed wait_, it is only valid to wait on `WGPUFuture`s originating from a single `WGPUQueue`. Waiting on two futures from different queues, or waiting on a Queue-timeline future and some other CPU-timeline future is an error.
 
 #### CPU-Timeline Operations
- - ::wgpuInstanceRequestAdapter
- - ::wgpuAdapterRequestDevice
- - ::wgpuShaderModuleGetCompilationInfo
- - ::wgpuDeviceCreateRenderPipelineAsync
- - ::wgpuDeviceCreateComputePipelineAsync
- - ::wgpuDevicePopErrorScope
+
+- ::wgpuInstanceRequestAdapter
+- ::wgpuAdapterRequestDevice
+- ::wgpuShaderModuleGetCompilationInfo
+- ::wgpuDeviceCreateRenderPipelineAsync
+- ::wgpuDeviceCreateComputePipelineAsync
+- ::wgpuDevicePopErrorScope
 
 #### Queue-Timeline Operations
- - ::wgpuBufferMapAsync
- - ::wgpuQueueOnSubmittedWorkDone
+
+- ::wgpuBufferMapAsync
+- ::wgpuQueueOnSubmittedWorkDone
 
 ## wgpuInstanceProcessEvents {#Process-Events}
 `void wgpuInstanceProcessEvents(WGPUInstance)`

--- a/doc/articles/Asynchronous Operations.md
+++ b/doc/articles/Asynchronous Operations.md
@@ -41,10 +41,13 @@ The `callback` function pointer is called when the application _observes complet
 
 Waits on any WGPUFuture in the list of `futures` to complete for `timeoutNS` nanoseconds. Returns when at least one `WGPUFuture` is completed or `timeoutNS` elapses, whichever is first. If `timeoutNS` is zero, all `futures` are polled once, without blocking.
 
-Returns @ref WGPUWaitStatus_Success if at least one `WGPUFuture` completes. WGPUFutureWaitInfo::completed is set to true for all completed futures. See @ref WGPUWaitStatus for other status codes.
-
-Within this call, for any `WGPUFuture`s that completed, their respective callbacks will fire.
-Note that the timeout applies only to the "wait" phase, and does not affect the callback firing phase.
+- Returns @ref WGPUWaitStatus_Success if at least one `WGPUFuture` completes. Each future which _just_ completed has its respective callback fired. Each future which _is_ complete has its corresponding @ref WGPUFutureWaitInfo::completed is set to true.
+  - Note that the timeout applies only to the "wait" phase, and does not affect the callback firing phase.
+- Returns @ref WGPUWaitStatus_TimedOut if the timeout passed without any futures completing.
+- Returns @ref WGPUWaitStatus_Error if the call was invalid for any of the following reasons:
+  - A @ref Timed-Wait was performed when WGPUInstanceFeatures::timedWaitAnyEnable is not enabled.
+  - The number of futures waited on in a @ref Timed-Wait is greater than the enabled WGPUInstanceFeatures::timedWaitAnyMaxCount.
+  - A wait was attempted with @ref Mixed-Sources.
 
 ### Timed Wait {#Timed-Wait}
 

--- a/webgpu.h
+++ b/webgpu.h
@@ -1125,24 +1125,15 @@ typedef enum WGPUWaitStatus {
     WGPUWaitStatus_Success = 0x00000001,
     /**
      * `0x00000002`.
-     * No WGPUFutures completed within the timeout.
+     * The wait operation succeeded, but no WGPUFutures completed within the timeout.
      */
     WGPUWaitStatus_TimedOut = 0x00000002,
     /**
      * `0x00000003`.
-     * A @ref Timed-Wait was performed when WGPUInstanceFeatures::timedWaitAnyEnable is false.
+     * The call was invalid for some reason (see @ref Wait-Any).
+     * Should produce @ref ImplementationDefinedLogging containing details.
      */
-    WGPUWaitStatus_UnsupportedTimeout = 0x00000003,
-    /**
-     * `0x00000004`.
-     * The number of futures waited on in a @ref Timed-Wait is greater than the supported WGPUInstanceFeatures::timedWaitAnyMaxCount.
-     */
-    WGPUWaitStatus_UnsupportedCount = 0x00000004,
-    /**
-     * `0x00000005`.
-     * An invalid wait was performed with @ref Mixed-Sources.
-     */
-    WGPUWaitStatus_UnsupportedMixedSources = 0x00000005,
+    WGPUWaitStatus_Error = 0x00000003,
     WGPUWaitStatus_Force32 = 0x7FFFFFFF
 } WGPUWaitStatus WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1375,13 +1375,11 @@ enums:
       - name: success
         doc: At least one WGPUFuture completed successfully.
       - name: timed_out
-        doc: No WGPUFutures completed within the timeout.
-      - name: unsupported_timeout
-        doc: A @ref Timed-Wait was performed when WGPUInstanceFeatures::timedWaitAnyEnable is false.
-      - name: unsupported_count
-        doc: The number of futures waited on in a @ref Timed-Wait is greater than the supported WGPUInstanceFeatures::timedWaitAnyMaxCount.
-      - name: unsupported_mixed_sources
-        doc: An invalid wait was performed with @ref Mixed-Sources.
+        doc: The wait operation succeeded, but no WGPUFutures completed within the timeout.
+      - name: error
+        doc: |
+          The call was invalid for some reason (see @ref Wait-Any).
+          Should produce @ref ImplementationDefinedLogging containing details.
   - name: WGSL_language_feature_name
     doc: |
       TODO


### PR DESCRIPTION
Mentioned `WGPUWaitStatus` in #401 but I didn't think about simplifying it so we didn't discuss it.

Since we're relying now on "implementation-defined logging" to convey details we don't generally need detailed error codes for things that are just surface-level misuses of the API.

In `WGPUWaitStatus` we have three `Unsupported` cases:
- `WGPUWaitStatus_UnsupportedTimeout`
- `WGPUWaitStatus_UnsupportedCount`
- `WGPUWaitStatus_UnsupportedMixedSources`

I don't think these are cases that a program would actually respond to programmatically. So I'm proposing we simplify into just one `WGPUWaitStatus_Unsupported` or `WGPUWaitStatus_Error`, with implementation-defined logging.

I used `WGPUWaitStatus_Error` here.