### PR TITLE
Restore WGPUQueueWorkDoneStatus_Error

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -707,6 +707,11 @@ typedef enum WGPUQueryType {
 typedef enum WGPUQueueWorkDoneStatus {
     WGPUQueueWorkDoneStatus_Success = 0x00000001,
     WGPUQueueWorkDoneStatus_InstanceDropped = 0x00000002,
+    /**
+     * There was some deterministic error. (Note this is currently never used,
+     * but it will be relevant when it's possible to create a queue object.)
+     */
+    WGPUQueueWorkDoneStatus_Error = 0x00000003,
     WGPUQueueWorkDoneStatus_Force32 = 0x7FFFFFFF
 } WGPUQueueWorkDoneStatus WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -672,6 +672,10 @@ enums:
       - name: instance_dropped
         doc: |
           TODO
+      - name: error
+        doc: |
+          There was some deterministic error. (Note this is currently never used,
+          but it will be relevant when it's possible to create a queue object.)
   - name: request_adapter_status
     doc: |
       TODO


### PR DESCRIPTION
We know this will be useful, and adding it now avoids implementations needing to add it as an extension whenever they prototype multi-queue (which would be annoying because then we'd end up with a bunch of different values for this one status code).

Issue: #401
Partially reverts #464