### PR TITLE
Add subgroups feature

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -553,6 +553,7 @@ typedef enum WGPUFeatureName {
     WGPUFeatureName_Float32Blendable = 0x0000000E,
     WGPUFeatureName_ClipDistances = 0x0000000F,
     WGPUFeatureName_DualSourceBlending = 0x00000010,
+    WGPUFeatureName_Subgroups = 0x00000011,
     WGPUFeatureName_Force32 = 0x7FFFFFFF
 } WGPUFeatureName WGPU_ENUM_ATTRIBUTE;
 
@@ -1591,6 +1592,14 @@ typedef struct WGPUAdapterInfo {
      * The `INIT` macro sets this to `0`.
      */
     uint32_t deviceID;
+    /**
+     * The `INIT` macro sets this to `0`.
+     */
+    uint32_t subgroupMinSize;
+    /**
+     * The `INIT` macro sets this to `0`.
+     */
+    uint32_t subgroupMaxSize;
 } WGPUAdapterInfo WGPU_STRUCTURE_ATTRIBUTE;
 
 /**
@@ -1606,6 +1615,8 @@ typedef struct WGPUAdapterInfo {
     /*.adapterType=*/_wgpu_ENUM_ZERO_INIT(WGPUAdapterType) _wgpu_COMMA \
     /*.vendorID=*/0 _wgpu_COMMA \
     /*.deviceID=*/0 _wgpu_COMMA \
+    /*.subgroupMinSize=*/0 _wgpu_COMMA \
+    /*.subgroupMaxSize=*/0 _wgpu_COMMA \
 })
 
 /**

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -478,6 +478,9 @@ enums:
       - name: dual_source_blending
         doc: |
           TODO
+      - name: subgroups
+        doc: |
+          TODO
   - name: filter_mode
     doc: |
       TODO
@@ -1561,6 +1564,14 @@ structs:
           TODO
         type: uint32
       - name: device_ID
+        doc: |
+          TODO
+        type: uint32
+      - name: subgroup_min_size
+        doc: |
+          TODO
+        type: uint32
+      - name: subgroup_max_size
         doc: |
           TODO
         type: uint32


### PR DESCRIPTION
This has been standardized in the JS API, so we can add it now.

Small breaking change by adding items to WGPUAdapterInfo, but these items can always be populated, in the same way they are in JS, so they don't need to be in an extension struct.

Fixes #428