### PR TITLE
Renames PopErrorScopeStatus Error to EmptyStack.

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -634,7 +634,7 @@ typedef enum WGPUPopErrorScopeStatus {
     /**
      * The error scope stack could not be popped, because it was empty.
      */
-    WGPUPopErrorScopeStatus_Error = 0x00000003,
+    WGPUPopErrorScopeStatus_EmptyStack = 0x00000003,
     WGPUPopErrorScopeStatus_Force32 = 0x7FFFFFFF
 } WGPUPopErrorScopeStatus WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -582,7 +582,7 @@ enums:
       - name: instance_dropped
         doc: |
           TODO
-      - name: error
+      - name: empty_stack
         doc: |
           The error scope stack could not be popped, because it was empty.
   - name: power_preference


### PR DESCRIPTION
Fixes: https://github.com/webgpu-native/webgpu-headers/issues/369