### PR TITLE
Update generator to use prefixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ help:
 fix: webgpu.yml
 	go run ./fix -yaml webgpu.yml
 
-gen: schema.json webgpu.yml
-	go run ./gen -schema schema.json -yaml webgpu.yml -header webgpu.h
+gen: schema.json webgpu.yml tests/extensions/extension.yml
+	go run ./gen -schema schema.json -yaml webgpu.yml -header webgpu.h -yaml tests/extensions/extension.yml -header tests/extensions/webgpu_extension.h
 
 gen-check: fix gen
 	@git diff --quiet -- webgpu.h || {                                                      \
@@ -26,6 +26,16 @@ gen-check: fix gen
 		echo "error: Please re-run 'make fix' to format the yml"; \
 		git diff -- webgpu.yml;                                   \
 		exit 1;                                                   \
+	}
+	@git diff --quiet -- tests/extensions/webgpu_extension.h || {                                       \
+		echo "error: The re-generated extensions header from yml doesn't match the checked-in header"; \
+		git diff -- tests/extensions/webgpu_extension.h;                                                \
+		exit 1;                                                                                        \
+	}
+	@git diff --quiet -- tests/extensions/extension.yml || {                \
+		echo "error: Please re-run 'make fix' to format the extension yml"; \
+		git diff -- tests/extensions/extension.yml;                         \
+		exit 1;                                                             \
 	}
 
 doc: webgpu.h Doxyfile

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ all-help-message: help
 help:
 	@echo 'Targets are: all, help, fix, gen, gen-check, doc'
 
-fix: webgpu.yml
+fix: webgpu.yml tests/extensions/extension.yml
 	go run ./fix -yaml webgpu.yml
+	go run ./fix -yaml tests/extensions/extension.yml
 
 gen: schema.json webgpu.yml tests/extensions/extension.yml
 	go run ./gen -schema schema.json -yaml webgpu.yml -header webgpu.h -yaml tests/extensions/extension.yml -header tests/extensions/webgpu_extension.h

--- a/fix/main.go
+++ b/fix/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	yamlPath   string
+	yamlPath string
 )
 
 func main() {

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -6,6 +6,7 @@
 #ifndef {{.HeaderName | ConstantCase}}_H_
 #define {{.HeaderName | ConstantCase}}_H_
 
+{{ if eq .Name "webgpu" -}}
 #if defined(WGPU_SHARED_LIBRARY)
 #    if defined(_WIN32)
 #        if defined(WGPU_IMPLEMENTATION)
@@ -38,27 +39,12 @@
 #endif
 #if !defined(WGPU_NULLABLE)
 #define WGPU_NULLABLE
-#endif{{"\n" -}}
-
-{{- if ne .Name "webgpu"}}
-#if !defined(_wgpu_EXTEND_ENUM)
-#ifdef __cplusplus
-#define _wgpu_EXTEND_ENUM(E, N, V) static const E N = E(V)
-#else
-#define _wgpu_EXTEND_ENUM(E, N, V) static const E N = (E)(V)
 #endif
-#endif // !defined(_wgpu_EXTEND_ENUM)
-{{ end}}
 
-{{- if eq .Name "webgpu"}}
 #include <stdint.h>
 #include <stddef.h>
 #include <math.h>
-{{else}}
-#include "webgpu.h"
-{{end}}
 
-{{- if eq .Name "webgpu"}}
 #define _wgpu_COMMA ,
 #if defined(__cplusplus)
 #  define _wgpu_ENUM_ZERO_INIT(type) type(0)
@@ -77,7 +63,17 @@
 #    define _wgpu_MAKE_INIT_STRUCT(type, value) value
 #  endif
 #endif
-{{end}}
+{{- else -}}
+#include "webgpu.h"
+
+#if !defined(_wgpu_EXTEND_ENUM)
+#ifdef __cplusplus
+#define _wgpu_EXTEND_ENUM(E, N, V) static const E N = E(V)
+#else
+#define _wgpu_EXTEND_ENUM(E, N, V) static const E N = (E)(V)
+#endif
+#endif // !defined(_wgpu_EXTEND_ENUM)
+{{- end }}
 
 /**
  * \defgroup Constants Constants
@@ -86,12 +82,10 @@
  * @{
  */
 
-{{- if .Constants}}
 {{-   range .Constants}}
 {{-     MComment .Doc 0}}
-#define WGPU_{{.Name | ConstantCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} ({{.Value | CValue}})
+#define WGPU_{{ConstantCaseName .Base}} ({{.Value | CValue}})
 {{-   end}}
-{{  end}}
 
 /** @} */
 
@@ -100,11 +94,7 @@
  *
  * @{
  */
-
-{{- if eq .Name "webgpu"}}
-typedef uint64_t WGPUFlags;
-typedef uint32_t WGPUBool;
-
+{{  if eq .Name "webgpu"}}
 /**
  * Nullable value defining a pointer+length view into a UTF-8 encoded string.
  *
@@ -144,11 +134,14 @@ typedef struct WGPUStringView {
     /*.data=*/NULL _wgpu_COMMA \
     /*.length=*/WGPU_STRLEN _wgpu_COMMA \
 })
-{{  end}}
+
+typedef uint64_t WGPUFlags;
+typedef uint32_t WGPUBool;
+{{- end }}
 {{- range .Typedefs}}
 {{-   MComment .Doc 0}}
-typedef {{CType .Type "" ""}} WGPU{{.Name | PascalCase}}{{$.ExtSuffix}};
-{{  end}}
+typedef {{CType .Type ""}} {{CType .Base ""}};
+{{- end}}
 
 /** @} */
 
@@ -159,30 +152,30 @@ typedef {{CType .Type "" ""}} WGPU{{.Name | PascalCase}}{{$.ExtSuffix}};
  * @{
  */
 
-{{- if .Objects}}
 {{-   range .Objects}}
-{{-     if not .IsStruct}}
+{{-     if and (not .IsStruct) (not .Extended)}}
 {{-   MComment .Doc 0}}
-typedef struct WGPU{{.Name | PascalCase}}{{$.ExtSuffix}}Impl* WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} WGPU_OBJECT_ATTRIBUTE;
+typedef struct {{CType .Base ""}}Impl* {{CType .Base ""}} WGPU_OBJECT_ATTRIBUTE;
 {{-     end}}
 {{-   end}}
-{{  end}}
 
 /** @} */
 
 {{- if .Structs}}
+
 // Structure forward declarations
 {{-   range .Structs}}
-struct WGPU{{.Name | PascalCase}}{{$.ExtSuffix}};
+struct {{CType .Base ""}};
 {{-   end}}
-{{  end}}
+{{- end}}
 
 {{- if .Callbacks}}
+
 // Callback info structure forward declarations
 {{-   range .Callbacks}}
-struct WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}};
+struct {{CType .Base ""}}CallbackInfo;
 {{-   end}}
-{{  end}}
+{{- end}}
 
 /**
  * \defgroup Enumerations Enumerations
@@ -192,26 +185,26 @@ struct WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}};
  */
 
 {{- range $enum := .Enums}}
+{{    MComment .Doc 0}}
 {{-   if .Extended}}
 {{-     range $entryIndex, $_ := .Entries}}
 {{-       if .}}
-_wgpu_EXTEND_ENUM(WGPU{{$enum.Name | PascalCase}}, WGPU{{$enum.Name | PascalCase}}_{{.Name | PascalCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}}, {{EnumValue32 $.EnumPrefix $enum $entryIndex | printf "0x%.8X"}});
+{{-         MCommentEnumValue .Doc 0 $enum $entryIndex }}
+_wgpu_EXTEND_ENUM({{CType $enum.Base ""}}, {{CEnumName $enum.Base .Base}}, {{EnumValue32 $enum $entryIndex | printf "0x%.8X"}});
 {{-       end}}
 {{-     end}}
 {{-   else}}
-{{-     MComment .Doc 0}}
-typedef enum WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} {
+typedef enum {{CType .Base ""}} {
 {{-     range $entryIndex, $_ := .Entries}}
 {{-       if .}}
-{{-         MCommentEnumValue .Doc 4 $.EnumPrefix $enum $entryIndex }}
-    WGPU{{$enum.Name | PascalCase}}_{{.Name | PascalCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} = {{EnumValue32 $.EnumPrefix $enum $entryIndex | printf "0x%.8X"}},
+{{-         MCommentEnumValue .Doc 4 $enum $entryIndex }}
+    {{CEnumName $enum.Base .Base}} = {{EnumValue32 $enum $entryIndex | printf "0x%.8X"}},
 {{-       end}}
 {{-     end}}
-    WGPU{{$enum.Name | PascalCase}}_Force32{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} = 0x7FFFFFFF
-} WGPU{{$enum.Name | PascalCase}}{{$.ExtSuffix}} WGPU_ENUM_ATTRIBUTE;
+    {{CType $enum.Base ""}}_Force32 = 0x7FFFFFFF
+} {{CType .Base ""}} WGPU_ENUM_ATTRIBUTE;
 {{-   end}}
-{{  end}}
-
+{{- end}}
 /** @} */
 
 /**
@@ -222,19 +215,22 @@ typedef enum WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} {
  */
 
 {{- range $bitflag := .Bitflags}}
-{{-   MCommentBitflagType .Doc 0}}
-typedef WGPUFlags WGPU{{.Name | PascalCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}};
+{{    MCommentBitflagType .Doc 0}}
+{{-   if not .Extended}}
+typedef WGPUFlags {{CType .Base ""}};
+{{-   end}}
 {{-   range $entryIndex, $_ := .Entries}}
 {{-     MCommentBitflagValue .Doc 0 $bitflag $entryIndex }}
-static const WGPU{{$bitflag.Name | PascalCase}} WGPU{{$bitflag.Name | PascalCase}}_{{.Name | PascalCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}} = {{BitflagValue $bitflag $entryIndex}};
+static const {{CType $bitflag.Base ""}} {{CEnumName $bitflag.Base .Base}} = {{BitflagValue $bitflag $entryIndex}};
 {{-   end}}
-{{  end}}
+{{- end}}
 
 /** @} */
 
 {{- if eq .Name "webgpu"}}
+
 typedef void (*WGPUProc)(void) WGPU_FUNCTION_ATTRIBUTE;
-{{  end}}
+{{- end}}
 
 /**
  * \defgroup Callbacks Callbacks
@@ -244,8 +240,8 @@ typedef void (*WGPUProc)(void) WGPU_FUNCTION_ATTRIBUTE;
  */
 
 {{- range .Callbacks}}
-{{-   MCommentCallback . 0}}
-typedef void (*WGPU{{.Name | PascalCase}}Callback{{$.ExtSuffix}})({{CallbackArgs .}}) WGPU_FUNCTION_ATTRIBUTE;
+{{    MCommentCallback . 0}}
+typedef void (*{{CType .Base ""}}Callback)({{CallbackArgs .}}) WGPU_FUNCTION_ATTRIBUTE;
 {{- end}}
 
 /** @} */
@@ -274,15 +270,15 @@ typedef struct WGPUChainedStruct {
  */
 
 /**
- * \defgroup WGPUCallbackInfo Callback Info Structs
+ * \defgroup CallbackInfoStructs Callback Info Structs
  * \brief Callback info structures that are used in asynchronous functions.
  *
  * @{
  */
 
 {{- range .Callbacks}}
-{{-   MComment .Doc 0}}
-typedef struct WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}} {
+{{    MComment .Doc 0}}
+typedef struct {{CType .Base ""}}CallbackInfo {
     WGPUChainedStruct * nextInChain;
 {{-   if eq .Style "callback_mode" }}
     /**
@@ -292,15 +288,15 @@ typedef struct WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}} {
      */
     WGPUCallbackMode mode;
 {{-   end}}
-    WGPU{{.Name | PascalCase}}Callback{{$.ExtSuffix}} callback;
+    {{CType .Base ""}}Callback callback;
     WGPU_NULLABLE void* userdata1;
     WGPU_NULLABLE void* userdata2;
-} WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}} WGPU_STRUCTURE_ATTRIBUTE;
+} {{CType .Base ""}}CallbackInfo WGPU_STRUCTURE_ATTRIBUTE;
 
 /**
- * Initializer for @ref WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}}.
+ * Initializer for @ref {{CType .Base ""}}CallbackInfo.
  */
-#define WGPU_{{.Name | ConstantCase}}_CALLBACK_INFO{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}}_INIT _wgpu_MAKE_INIT_STRUCT(WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}}, { \
+#define WGPU_{{ConstantCaseName .Base}}_CALLBACK_INFO_INIT _wgpu_MAKE_INIT_STRUCT({{CType .Base ""}}CallbackInfo, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
 {{-   if eq .Style "callback_mode" }}
     /*.mode=*/_wgpu_ENUM_ZERO_INIT(WGPUCallbackMode) _wgpu_COMMA \
@@ -309,14 +305,14 @@ typedef struct WGPU{{.Name | PascalCase}}CallbackInfo{{$.ExtSuffix}} {
     /*.userdata1=*/NULL _wgpu_COMMA \
     /*.userdata2=*/NULL _wgpu_COMMA \
 })
-{{  end}}{{"\n" -}}
+{{- end}}
 
 /** @} */
 
 {{- "\n"}}
 {{- range $struct := .Structs}}
 {{-   MCommentStruct . 0}}
-typedef struct WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} {
+typedef struct {{CType .Base ""}} {
 {{-   if or (eq .Type "extensible") (eq .Type "extensible_callback_arg") }}
     WGPUChainedStruct * nextInChain;
 {{-   else if eq .Type "extension"}}
@@ -335,18 +331,18 @@ typedef struct WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} {
     {{  StructMember $struct $memberIndex}}
 {{-     end}}
 {{-   end}}
-} WGPU{{.Name | PascalCase}}{{$.ExtSuffix}} WGPU_STRUCTURE_ATTRIBUTE;
+} {{CType .Base ""}} WGPU_STRUCTURE_ATTRIBUTE;
 
 /**
- * Initializer for @ref WGPU{{.Name | PascalCase}}{{$.ExtSuffix}}.
+ * Initializer for @ref {{CType .Base ""}}.
  */
-#define WGPU_{{.Name | ConstantCase}}{{if $.ExtSuffix}}_{{$.ExtSuffix}}{{end}}_INIT _wgpu_MAKE_INIT_STRUCT(WGPU{{.Name | PascalCase}}{{$.ExtSuffix}}, { \
+#define WGPU_{{ConstantCaseName .Base}}_INIT _wgpu_MAKE_INIT_STRUCT({{CType .Base ""}}, { \
 {{-   if or (eq .Type "extensible") (eq .Type "extensible_callback_arg") }}
     /*.nextInChain=*/NULL _wgpu_COMMA \
 {{-   else if eq .Type "extension" }}
     /*.chain=*/_wgpu_MAKE_INIT_STRUCT(WGPUChainedStruct, { \
         /*.next=*/NULL _wgpu_COMMA \
-        /*.sType=*/WGPUSType_{{.Name | PascalCase}}{{$.ExtSuffix}} _wgpu_COMMA \
+        /*.sType=*/WGPUSType_{{PascalCaseName .Base}} _wgpu_COMMA \
     }) _wgpu_COMMA \
 {{-   end }}
 {{-   range $memberIndex, $_ := .Members}}
@@ -363,12 +359,13 @@ extern "C" {
 
 #if !defined(WGPU_SKIP_PROCS){{"\n" -}}
 
+// Global procs
 {{- range .Functions}}
 /**
- * Proc pointer type for @ref wgpu{{.Name | PascalCase}}{{$.ExtSuffix}}:
- * > @copydoc wgpu{{.Name | PascalCase}}{{$.ExtSuffix}}
+ * Proc pointer type for @ref wgpu{{PascalCaseName .Base}}:
+ * > @copydoc wgpu{{PascalCaseName .Base}}
  */
-typedef {{FunctionReturns .}} (*WGPUProc{{.Name | PascalCase}}{{$.ExtSuffix}})({{FunctionArgs . nil}}) WGPU_FUNCTION_ATTRIBUTE;
+typedef {{FunctionReturns .}} (*WGPUProc{{PascalCaseName .Base}})({{FunctionArgs . nil}}) WGPU_FUNCTION_ATTRIBUTE;
 {{- end}}
 {{- if eq .Name "webgpu"}}
 /**
@@ -379,27 +376,16 @@ typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUStringView procName) WGPU_FUNCTIO
 {{  end}}
 
 {{- range $object := .Objects}}
-// Procs of {{$object.Name | PascalCase}}
+
+// Procs of {{PascalCaseName $object.Base}}
 {{-   range $object.Methods}}
 /**
- * Proc pointer type for @ref wgpu{{$object.Name | PascalCase}}{{.Name | PascalCase}}{{$.ExtSuffix}}:
- * > @copydoc wgpu{{$object.Name | PascalCase}}{{.Name | PascalCase}}{{$.ExtSuffix}}
+ * Proc pointer type for @ref wgpu{{CMethodName $object .}}:
+ * > @copydoc wgpu{{CMethodName $object .}}
  */
-typedef {{FunctionReturns .}} (*WGPUProc{{$object.Name | PascalCase}}{{.Name | PascalCase}}{{$.ExtSuffix}})({{FunctionArgs . $object}}) WGPU_FUNCTION_ATTRIBUTE;
+typedef {{FunctionReturns .}} (*WGPUProc{{CMethodName $object .}})({{FunctionArgs . $object}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-   end}}
-{{-   if not (or .IsStruct .Extended)}}
-/**
- * Proc pointer type for @ref wgpu{{$object.Name | PascalCase}}AddRef{{$.ExtSuffix}}.
- * > @copydoc wgpu{{$object.Name | PascalCase}}AddRef{{$.ExtSuffix}}
- */
-typedef void (*WGPUProc{{.Name | PascalCase}}AddRef{{$.ExtSuffix}})(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
-/**
- * Proc pointer type for @ref wgpu{{$object.Name | PascalCase}}Release{{$.ExtSuffix}}.
- * > @copydoc wgpu{{$object.Name | PascalCase}}Release{{$.ExtSuffix}}
- */
-typedef void (*WGPUProc{{.Name | PascalCase}}Release{{$.ExtSuffix}})(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
-{{-   end}}
-{{  end}}{{"\n" -}}
+{{- end}}
 
 #endif  // !defined(WGPU_SKIP_PROCS)
 
@@ -414,7 +400,7 @@ typedef void (*WGPUProc{{.Name | PascalCase}}Release{{$.ExtSuffix}})(WGPU{{.Name
 
 {{- range .Functions}}
 {{-   MCommentFunction . 0}}
-WGPU_EXPORT {{FunctionReturns .}} wgpu{{.Name | PascalCase}}{{$.ExtSuffix}}({{FunctionArgs . nil}}) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT {{FunctionReturns .}} wgpu{{PascalCaseName .Base}}({{FunctionArgs . nil}}) WGPU_FUNCTION_ATTRIBUTE;
 {{- end}}
 {{- if eq .Name "webgpu"}}
 /**
@@ -436,22 +422,17 @@ WGPU_EXPORT WGPUProc wgpuGetProcAddress(WGPUStringView procName) WGPU_FUNCTION_A
 {{- range $object := .Objects}}
 
 /**
- * \defgroup WGPU{{$object.Name | PascalCase}}Methods WGPU{{$object.Name | PascalCase}} methods
- * \brief Functions whose first argument has type WGPU{{$object.Name | PascalCase}}.
+ * \defgroup WGPU{{PascalCaseName $object.Base}}Methods WGPU{{PascalCaseName $object.Base}} methods
+ * \brief Functions whose first argument has type WGPU{{PascalCaseName $object.Base}}.
  *
  * @{
  */
 {{-   range $object.Methods}}
 {{-     MCommentFunction . 0}}
-WGPU_EXPORT {{FunctionReturns .}} wgpu{{$object.Name | PascalCase}}{{.Name | PascalCase}}{{$.ExtSuffix}}({{FunctionArgs . $object}}) WGPU_FUNCTION_ATTRIBUTE;
-{{-   end}}
-{{-   if not (or .IsStruct .Extended)}}
-WGPU_EXPORT void wgpu{{.Name | PascalCase}}AddRef{{$.ExtSuffix}}(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpu{{.Name | PascalCase}}Release{{$.ExtSuffix}}(WGPU{{.Name | PascalCase}} {{.Name | CamelCase}}) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT {{FunctionReturns .}} wgpu{{CMethodName $object .}}({{FunctionArgs . $object}}) WGPU_FUNCTION_ATTRIBUTE;
 {{-   end}}
 /** @} */
-
-{{  end}}{{"\n" -}}
+{{- end}}
 
 /** @} */
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -455,7 +455,7 @@ func (g *Generator) FunctionArgs(f Function, o *Object) string {
 		}
 	}
 	if f.Callback != nil {
-		fmt.Fprintf(sb, ", %s callbackInfo", g.CType(*f.Callback, "")+"CallbackInfo")
+		fmt.Fprintf(sb, ", %sCallbackInfo callbackInfo", g.CType(*f.Callback, ""))
 	}
 	return sb.String()
 }
@@ -605,7 +605,7 @@ func (g *Generator) StructMember(s Struct, memberIndex int) (string, error) {
 		sb.WriteString("WGPU_NULLABLE ")
 	}
 	if strings.HasPrefix(member.Type, "callback.") {
-		fmt.Fprintf(sb, "%s %s;", g.CType(member.Type, "")+"CallbackInfo", CamelCase(member.Name))
+		fmt.Fprintf(sb, "%sCallbackInfo %s;", g.CType(member.Type, ""), CamelCase(member.Name))
 	} else {
 		fmt.Fprintf(sb, "%s %s;", g.CType(member.Type, member.Pointer), CamelCase(member.Name))
 	}

--- a/gen/yml.go
+++ b/gen/yml.go
@@ -23,39 +23,38 @@ type Yml struct {
 	Objects   []Object   `yaml:"objects"`
 }
 
+type Base struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+	Doc       string `yaml:"doc"`
+	Extended  bool   `yaml:"extended"`
+}
+
 type Constant struct {
-	Name  string `yaml:"name"`
+	Base  `yaml:",inline"`
 	Value string `yaml:"value"`
-	Doc   string `yaml:"doc"`
 }
 
 type Typedef struct {
-	Name string `yaml:"name"`
-	Doc  string `yaml:"doc"`
+	Base `yaml:",inline"`
 	Type string `yaml:"type"`
 }
 
 type Enum struct {
-	Name     string       `yaml:"name"`
-	Doc      string       `yaml:"doc"`
-	Entries  []*EnumEntry `yaml:"entries"`
-	Extended bool         `yaml:"extended"`
+	Base    `yaml:",inline"`
+	Entries []*EnumEntry `yaml:"entries"`
 }
 type EnumEntry struct {
-	Name  string `yaml:"name"`
-	Doc   string `yaml:"doc"`
+	Base  `yaml:",inline"`
 	Value string `yaml:"value"`
 }
 
 type Bitflag struct {
-	Name     string         `yaml:"name"`
-	Doc      string         `yaml:"doc"`
-	Entries  []BitflagEntry `yaml:"entries"`
-	Extended bool           `yaml:"extended"`
+	Base    `yaml:",inline"`
+	Entries []BitflagEntry `yaml:"entries"`
 }
 type BitflagEntry struct {
-	Name             string   `yaml:"name"`
-	Doc              string   `yaml:"doc"`
+	Base             `yaml:",inline"`
 	Value            string   `yaml:"value"`
 	ValueCombination []string `yaml:"value_combination"`
 }
@@ -69,44 +68,38 @@ const (
 
 type ParameterType struct {
 	Name                string      `yaml:"name"`
+	Namespace           string      `yaml:"namespace"`
 	Doc                 string      `yaml:"doc"`
 	Type                string      `yaml:"type"`
 	PassedWithOwnership *bool       `yaml:"passed_with_ownership"`
 	Pointer             PointerType `yaml:"pointer"`
 	Optional            bool        `yaml:"optional"`
-	Namespace           string      `yaml:"namespace"`
 	Default             *string     `yaml:"default"`
 }
 
 type Callback struct {
-	Name  string          `yaml:"name"`
-	Doc   string          `yaml:"doc"`
+	Base  `yaml:",inline"`
 	Style string          `yaml:"style"`
 	Args  []ParameterType `yaml:"args"`
 }
 
 type Function struct {
-	Name     string          `yaml:"name"`
-	Doc      string          `yaml:"doc"`
+	Base     `yaml:",inline"`
 	Returns  *ParameterType  `yaml:"returns"`
 	Callback *string         `yaml:"callback"`
 	Args     []ParameterType `yaml:"args"`
 }
 
 type Struct struct {
-	Name        string          `yaml:"name"`
+	Base        `yaml:",inline"`
 	Type        string          `yaml:"type"`
-	Doc         string          `yaml:"doc"`
 	FreeMembers bool            `yaml:"free_members"`
 	Members     []ParameterType `yaml:"members"`
 }
 
 type Object struct {
-	Name      string     `yaml:"name"`
-	Doc       string     `yaml:"doc"`
-	Methods   []Function `yaml:"methods"`
-	Extended  bool       `yaml:"extended"`
-	Namespace string     `yaml:"namespace"`
+	Base    `yaml:",inline"`
+	Methods []Function `yaml:"methods"`
 
 	IsStruct bool `yaml:"-"`
 }

--- a/schema.json
+++ b/schema.json
@@ -267,7 +267,7 @@
         "enum_prefix": {
             "type": "number",
             "minimum": 0,
-            "maximum": 65535,
+            "maximum": 32767,
             "description": "The dedicated enum prefix for the implementation specific header to avoid collisions"
         },
         "doc": {

--- a/schema.json
+++ b/schema.json
@@ -103,6 +103,11 @@
                     "$ref": "#/definitions/Name",
                     "description": "Callback name"
                 },
+                "namespace": {
+                    "type": "string",
+                    "description": "Optional property, specifying the namespace where this callback is defined",
+                    "pattern": "^[a-z]+$"
+                },
                 "doc": {
                     "type": "string"
                 },
@@ -151,11 +156,6 @@
                     "type": "boolean",
                     "description": "Optional property, to indicate if a parameter is optional"
                 },
-                "namespace": {
-                    "type": "string",
-                    "description": "Optional property, specifying the external namespace where this type is defined",
-                    "pattern": "^[a-z]+$"
-                },
                 "default": {
                     "type": [
                         "string",
@@ -196,6 +196,11 @@
                 "name": {
                     "$ref": "#/definitions/Name",
                     "description": "Name of the function"
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "Optional property, specifying the namespace where this function is defined",
+                    "pattern": "^[a-z]+$"
                 },
                 "doc": {
                     "type": "string"
@@ -278,6 +283,11 @@
                     "name": {
                         "$ref": "#/definitions/Name"
                     },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional property, specifying the namespace where this typedef is defined",
+                        "pattern": "^[a-z]+$"
+                    },
                     "doc": {
                         "type": "string"
                     },
@@ -301,6 +311,11 @@
                     "name": {
                         "$ref": "#/definitions/Name",
                         "description": "Name of the constant variable/define"
+                    },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional property, specifying the namespace where this constant is defined",
+                        "pattern": "^[a-z]+$"
                     },
                     "value": {
                         "$ref": "#/definitions/Value64",
@@ -327,6 +342,11 @@
                         "$ref": "#/definitions/Name",
                         "description": "Name of the enum"
                     },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional property, specifying the namespace where this enum is defined",
+                        "pattern": "^[a-z]+$"
+                    },
                     "doc": {
                         "type": "string"
                     },
@@ -349,6 +369,11 @@
                                         "name": {
                                             "$ref": "#/definitions/Name",
                                             "description": "Name of the enum entry"
+                                        },
+                                        "namespace": {
+                                            "type": "string",
+                                            "description": "Optional property, specifying the namespace where this enum entry is defined",
+                                            "pattern": "^[a-z]+$"
                                         },
                                         "doc": {
                                             "type": "string"
@@ -383,6 +408,11 @@
                         "$ref": "#/definitions/Name",
                         "description": "Name of the bitflag"
                     },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional property, specifying the namespace where this bitflag is defined",
+                        "pattern": "^[a-z]+$"
+                    },
                     "doc": {
                         "type": "string"
                     },
@@ -399,6 +429,11 @@
                                 "name": {
                                     "$ref": "#/definitions/Name",
                                     "description": "Name of the bitflag entry"
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "Optional property, specifying the namespace where this bitmask entry is defined",
+                                    "pattern": "^[a-z]+$"
                                 },
                                 "doc": {
                                     "type": "string"
@@ -437,6 +472,11 @@
                     "name": {
                         "$ref": "#/definitions/Name",
                         "description": "Name of the structure"
+                    },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional property, specifying the namespace where this struct is defined",
+                        "pattern": "^[a-z]+$"
                     },
                     "doc": {
                         "type": "string"
@@ -499,17 +539,17 @@
                         "$ref": "#/definitions/Name",
                         "description": "Name of the object"
                     },
+                    "namespace": {
+                        "type": "string",
+                        "description": "Optional property, specifying the namespace where this object is defined",
+                        "pattern": "^[a-z]+$"
+                    },
                     "doc": {
                         "type": "string"
                     },
                     "extended": {
                         "type": "boolean",
                         "description": "Optional property, an indicator that this object is an extension of an already present object"
-                    },
-                    "namespace": {
-                        "type": "string",
-                        "description": "Optional property, specifying the external namespace where this object is defined",
-                        "pattern": "^[a-z]+$"
                     },
                     "methods": {
                         "type": "array",

--- a/tests/extensions/extension.yml
+++ b/tests/extensions/extension.yml
@@ -6,7 +6,7 @@ name: prefix
 enum_prefix: 0xFFFF
 doc: |
   This is a bare minimum extensions file to verify all extension types.
-constants: 
+constants:
   - name: new_constant1
     value: uint32_max
     doc: |

--- a/tests/extensions/extension.yml
+++ b/tests/extensions/extension.yml
@@ -1,0 +1,167 @@
+copyright: |
+  Copyright 2025 WebGPU-Native developers
+
+  SPDX-License-Identifier: BSD-3-Clause
+name: prefix
+enum_prefix: 0xFFFF
+doc: |
+  This is a bare minimum extensions file to verify all extension types.
+constants: 
+  - name: new_constant1
+    value: uint32_max
+    doc: |
+      New constant should have the namespace prefix in the name by default.
+  - name: new_constant2
+    namespace: webgpu
+    value: uint64_max
+    doc: |
+      New constant can be declared in the 'webgpu' namespace explicitly.
+typedefs:
+  - name: new_typedef1
+    type: uint32
+    doc: |
+      New typedef should have the namespace prefix in the name by default.
+  - name: new_typedef2
+    namespace: webgpu
+    type: uint64
+    doc: |
+      New typedef can be declared in the 'webgpu' namespace explicitly.
+enums:
+  - name: new_enum1
+    doc: |
+      New enum should have the namespace prefix in the name by default.
+    entries:
+      - name: new_value
+        doc: |
+          New enum entries for a new enum should not duplicate prefix.
+  - name: new_enum2
+    namespace: webgpu
+    doc: |
+      New enum can be declared in the 'webgpu' namespace explicitly.
+    entries:
+      - name: new_value
+        doc: |
+          New enum entries for a new enum should not duplicate prefix.
+  - name: old_enum
+    doc: |
+      Extended enum shouldn't have the namespace prefix in the name by default.
+    extended: True
+    entries:
+      - name: new_value
+        doc: |
+          New enum entries that extend should have the prefix in the name by default.
+bitflags:
+  - name: new_bitflag1
+    doc: |
+      New bitflag should have the namespace prefix in the name by default.
+    entries:
+      - name: none
+        doc: |
+          TODO
+      - name: new_value
+        doc: |
+          New bitflag entries shouldn't have the namespace prefix in the name by default.
+  - name: new_bitflag2
+    namespace: webgpu
+    doc: |
+      New bitflag can be declared in the 'webgpu' namespace explicitly.
+    entries:
+      - name: none
+        doc: |
+          TODO
+      - name: new_value
+        doc: |
+          New bitflag entries shouldn't have the namespace prefix in the name by default.
+  - name: old_bitflag
+    doc: |
+      Extended bitflag shouldn't have the namespace prefix in the name by default.
+    extended: True
+    entries:
+      - name: new_value
+        doc: |
+          New bitflag entries that extend should have the prefix in the name by default.
+        value: 0x1000000000000000
+structs:
+  - name: new_struct1
+    doc: |
+      New struct should have the namespace prefix in the name by default.
+    type: standalone
+    members:
+      - name: member1
+        doc: |
+          New struct members should not have namespace prefix in the name.
+        type: uint32
+        default: constant.new_constant1
+      - name: member2
+        doc: |
+          TODO
+        type: uint64
+        default: constant.new_constant2
+  - name: new_struct2
+    namespace: webgpu
+    doc: |
+      New struct can be declared in the 'webgpu' namespace explicitly.
+    type: extensible
+    members:
+      - name: struct_member
+        doc: |
+          TODO
+        type: struct.new_struct1
+callbacks:
+  - name: new_callback1
+    doc: |
+      New callback type should have the namespace prefix in the names by default.
+    style: callback_mode
+    args:
+      - name: message
+        doc: |
+          TODO
+        type: out_string
+        passed_with_ownership: false
+  - name: new_callback2
+    namespace: webgpu
+    doc: |
+      New callback type can be declared in the 'webgpu' namespace explicitly.
+    style: callback_mode
+    args:
+      - name: message
+        doc: |
+          TODO
+        type: out_string
+        passed_with_ownership: false
+functions:
+  - name: new_function1
+    doc: |
+      New function should have the namespace prefix in the name by default.
+  - name: new_function2
+    namespace: webgpu
+    doc: |
+      New function can be declared in the 'webgpu' namespace explicitly.
+objects:
+  - name: new_object1
+    doc: |
+      New object should have the namespace prefix in the name by default.
+    methods:
+      - name: new_method
+        doc: |
+          Method on new object should not have the namespace prefix in the name by default.
+  - name: new_object2
+    namespace: webgpu
+    doc: |
+      New object can be declared in the 'webgpu' namespace explicitly.
+    methods:
+      - name: new_method
+        doc: |
+          Method on new object should not have the namespace prefix in the name by default.
+  - name: old_object
+    doc: |
+      Extended object shouldn't have the namespace prefix in the name by default.
+    extended: True
+    methods:
+      - name: new_method1
+        doc: |
+          New method on old object should have the namespace prefix in the name by default.
+      - name: new_method2
+        namespace: webgpu
+        doc: |
+          New method on old object can be declared in the 'webgpu' namespace explicitly.

--- a/tests/extensions/extension.yml
+++ b/tests/extensions/extension.yml
@@ -3,7 +3,7 @@ copyright: |
 
   SPDX-License-Identifier: BSD-3-Clause
 name: prefix
-enum_prefix: 0xFFFF
+enum_prefix: 0x7FFF
 doc: |
   This is a bare minimum extensions file to verify all extension types.
 constants:

--- a/tests/extensions/webgpu_extension.h
+++ b/tests/extensions/webgpu_extension.h
@@ -97,7 +97,7 @@ struct WGPUNewCallback2CallbackInfo;
 /**
  * New enum entries that extend should have the prefix in the name by default.
  */
-_wgpu_EXTEND_ENUM(WGPUOldEnum, WGPUOldEnum_PrefixNewValue, 0xFFFF0000);
+_wgpu_EXTEND_ENUM(WGPUOldEnum, WGPUOldEnum_PrefixNewValue, 0x7FFF0000);
 
 /**
  * New enum should have the namespace prefix in the name by default.
@@ -106,7 +106,7 @@ typedef enum WGPUPrefixNewEnum1 {
     /**
      * New enum entries for a new enum should not duplicate prefix.
      */
-    WGPUPrefixNewEnum1_NewValue = 0xFFFF0000,
+    WGPUPrefixNewEnum1_NewValue = 0x7FFF0000,
     WGPUPrefixNewEnum1_Force32 = 0x7FFFFFFF
 } WGPUPrefixNewEnum1 WGPU_ENUM_ATTRIBUTE;
 
@@ -117,7 +117,7 @@ typedef enum WGPUNewEnum2 {
     /**
      * New enum entries for a new enum should not duplicate prefix.
      */
-    WGPUNewEnum2_NewValue = 0xFFFF0000,
+    WGPUNewEnum2_NewValue = 0x7FFF0000,
     WGPUNewEnum2_Force32 = 0x7FFFFFFF
 } WGPUNewEnum2 WGPU_ENUM_ATTRIBUTE;
 /** @} */

--- a/tests/extensions/webgpu_extension.h
+++ b/tests/extensions/webgpu_extension.h
@@ -1,0 +1,464 @@
+/**
+ * Copyright 2025 WebGPU-Native developers
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/** @file */
+
+/**
+ * \mainpage
+ *
+ * This is a bare minimum extensions file to verify all extension types.
+ */
+
+#ifndef WEBGPU_EXTENSION_H_
+#define WEBGPU_EXTENSION_H_
+
+#include "webgpu.h"
+
+#if !defined(_wgpu_EXTEND_ENUM)
+#ifdef __cplusplus
+#define _wgpu_EXTEND_ENUM(E, N, V) static const E N = E(V)
+#else
+#define _wgpu_EXTEND_ENUM(E, N, V) static const E N = (E)(V)
+#endif
+#endif // !defined(_wgpu_EXTEND_ENUM)
+
+/**
+ * \defgroup Constants Constants
+ * \brief Constants.
+ *
+ * @{
+ */
+/**
+ * New constant should have the namespace prefix in the name by default.
+ */
+#define WGPU_PREFIX_NEW_CONSTANT1 (UINT32_MAX)
+/**
+ * New constant can be declared in the 'webgpu' namespace explicitly.
+ */
+#define WGPU_NEW_CONSTANT2 (UINT64_MAX)
+
+/** @} */
+
+/**
+ * \defgroup UtilityTypes Utility Types
+ *
+ * @{
+ */
+
+/**
+ * New typedef should have the namespace prefix in the name by default.
+ */
+typedef uint32_t WGPUPrefixNewTypedef1;
+/**
+ * New typedef can be declared in the 'webgpu' namespace explicitly.
+ */
+typedef uint64_t WGPUNewTypedef2;
+
+/** @} */
+
+/**
+ * \defgroup Objects Objects
+ * \brief Opaque, non-dispatchable handles to WebGPU objects.
+ *
+ * @{
+ */
+/**
+ * New object should have the namespace prefix in the name by default.
+ */
+typedef struct WGPUPrefixNewObject1Impl* WGPUPrefixNewObject1 WGPU_OBJECT_ATTRIBUTE;
+/**
+ * New object can be declared in the 'webgpu' namespace explicitly.
+ */
+typedef struct WGPUNewObject2Impl* WGPUNewObject2 WGPU_OBJECT_ATTRIBUTE;
+
+/** @} */
+
+// Structure forward declarations
+struct WGPUPrefixNewStruct1;
+struct WGPUNewStruct2;
+
+// Callback info structure forward declarations
+struct WGPUPrefixNewCallback1CallbackInfo;
+struct WGPUNewCallback2CallbackInfo;
+
+/**
+ * \defgroup Enumerations Enumerations
+ * \brief Enums.
+ *
+ * @{
+ */
+
+/**
+ * Extended enum shouldn't have the namespace prefix in the name by default.
+ */
+/**
+ * New enum entries that extend should have the prefix in the name by default.
+ */
+_wgpu_EXTEND_ENUM(WGPUOldEnum, WGPUOldEnum_PrefixNewValue, 0xFFFF0000);
+
+/**
+ * New enum should have the namespace prefix in the name by default.
+ */
+typedef enum WGPUPrefixNewEnum1 {
+    /**
+     * New enum entries for a new enum should not duplicate prefix.
+     */
+    WGPUPrefixNewEnum1_NewValue = 0xFFFF0000,
+    WGPUPrefixNewEnum1_Force32 = 0x7FFFFFFF
+} WGPUPrefixNewEnum1 WGPU_ENUM_ATTRIBUTE;
+
+/**
+ * New enum can be declared in the 'webgpu' namespace explicitly.
+ */
+typedef enum WGPUNewEnum2 {
+    /**
+     * New enum entries for a new enum should not duplicate prefix.
+     */
+    WGPUNewEnum2_NewValue = 0xFFFF0000,
+    WGPUNewEnum2_Force32 = 0x7FFFFFFF
+} WGPUNewEnum2 WGPU_ENUM_ATTRIBUTE;
+/** @} */
+
+/**
+ * \defgroup Bitflags Bitflags
+ * \brief Type and constant definitions for bitflag types.
+ *
+ * @{
+ */
+
+/**
+ * Extended bitflag shouldn't have the namespace prefix in the name by default.
+ *
+ * For reserved non-standard bitflag values, see @ref BitflagRegistry.
+ */
+/**
+ * New bitflag entries that extend should have the prefix in the name by default.
+ */
+static const WGPUOldBitflag WGPUOldBitflag_PrefixNewValue = 0x1000000000000000;
+
+/**
+ * New bitflag should have the namespace prefix in the name by default.
+ *
+ * For reserved non-standard bitflag values, see @ref BitflagRegistry.
+ */
+typedef WGPUFlags WGPUPrefixNewBitflag1;
+/**
+ * `0`.
+ */
+static const WGPUPrefixNewBitflag1 WGPUPrefixNewBitflag1_None = 0x0000000000000000;
+/**
+ * New bitflag entries shouldn't have the namespace prefix in the name by default.
+ */
+static const WGPUPrefixNewBitflag1 WGPUPrefixNewBitflag1_NewValue = 0x0000000000000001;
+
+/**
+ * New bitflag can be declared in the 'webgpu' namespace explicitly.
+ *
+ * For reserved non-standard bitflag values, see @ref BitflagRegistry.
+ */
+typedef WGPUFlags WGPUNewBitflag2;
+/**
+ * `0`.
+ */
+static const WGPUNewBitflag2 WGPUNewBitflag2_None = 0x0000000000000000;
+/**
+ * New bitflag entries shouldn't have the namespace prefix in the name by default.
+ */
+static const WGPUNewBitflag2 WGPUNewBitflag2_NewValue = 0x0000000000000001;
+
+/** @} */
+
+/**
+ * \defgroup Callbacks Callbacks
+ * \brief Callbacks through which asynchronous functions return.
+ *
+ * @{
+ */
+
+/**
+ * New callback type should have the namespace prefix in the names by default.
+ *
+ * See also @ref CallbackError.
+ *
+ * @param message
+ * This parameter is @ref PassedWithoutOwnership.
+ */
+typedef void (*WGPUPrefixNewCallback1Callback)(WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
+/**
+ * New callback type can be declared in the 'webgpu' namespace explicitly.
+ *
+ * See also @ref CallbackError.
+ *
+ * @param message
+ * This parameter is @ref PassedWithoutOwnership.
+ */
+typedef void (*WGPUNewCallback2Callback)(WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
+/** @} */
+
+/**
+ * \defgroup Structures Structures
+ * \brief Descriptors and other transparent structures.
+ *
+ * @{
+ */
+
+/**
+ * \defgroup CallbackInfoStructs Callback Info Structs
+ * \brief Callback info structures that are used in asynchronous functions.
+ *
+ * @{
+ */
+
+/**
+ * New callback type should have the namespace prefix in the names by default.
+ */
+typedef struct WGPUPrefixNewCallback1CallbackInfo {
+    WGPUChainedStruct * nextInChain;
+    /**
+     * Controls when the callback may be called.
+     *
+     * Has no default. The `INIT` macro sets this to (@ref WGPUCallbackMode)0.
+     */
+    WGPUCallbackMode mode;
+    WGPUPrefixNewCallback1Callback callback;
+    WGPU_NULLABLE void* userdata1;
+    WGPU_NULLABLE void* userdata2;
+} WGPUPrefixNewCallback1CallbackInfo WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Initializer for @ref WGPUPrefixNewCallback1CallbackInfo.
+ */
+#define WGPU_PREFIX_NEW_CALLBACK1_CALLBACK_INFO_INIT _wgpu_MAKE_INIT_STRUCT(WGPUPrefixNewCallback1CallbackInfo, { \
+    /*.nextInChain=*/NULL _wgpu_COMMA \
+    /*.mode=*/_wgpu_ENUM_ZERO_INIT(WGPUCallbackMode) _wgpu_COMMA \
+    /*.callback=*/NULL _wgpu_COMMA \
+    /*.userdata1=*/NULL _wgpu_COMMA \
+    /*.userdata2=*/NULL _wgpu_COMMA \
+})
+
+/**
+ * New callback type can be declared in the 'webgpu' namespace explicitly.
+ */
+typedef struct WGPUNewCallback2CallbackInfo {
+    WGPUChainedStruct * nextInChain;
+    /**
+     * Controls when the callback may be called.
+     *
+     * Has no default. The `INIT` macro sets this to (@ref WGPUCallbackMode)0.
+     */
+    WGPUCallbackMode mode;
+    WGPUNewCallback2Callback callback;
+    WGPU_NULLABLE void* userdata1;
+    WGPU_NULLABLE void* userdata2;
+} WGPUNewCallback2CallbackInfo WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Initializer for @ref WGPUNewCallback2CallbackInfo.
+ */
+#define WGPU_NEW_CALLBACK2_CALLBACK_INFO_INIT _wgpu_MAKE_INIT_STRUCT(WGPUNewCallback2CallbackInfo, { \
+    /*.nextInChain=*/NULL _wgpu_COMMA \
+    /*.mode=*/_wgpu_ENUM_ZERO_INIT(WGPUCallbackMode) _wgpu_COMMA \
+    /*.callback=*/NULL _wgpu_COMMA \
+    /*.userdata1=*/NULL _wgpu_COMMA \
+    /*.userdata2=*/NULL _wgpu_COMMA \
+})
+
+/** @} */
+
+/**
+ * New struct should have the namespace prefix in the name by default.
+ *
+ * Default values can be set using @ref WGPU_PREFIX_NEW_STRUCT1_INIT as initializer.
+ */
+typedef struct WGPUPrefixNewStruct1 {
+    /**
+     * New struct members should not have namespace prefix in the name.
+     *
+     * The `INIT` macro sets this to @ref WGPU_PREFIX_NEW_CONSTANT1.
+     */
+    uint32_t member1;
+    /**
+     * The `INIT` macro sets this to @ref WGPU_NEW_CONSTANT2.
+     */
+    uint64_t member2;
+} WGPUPrefixNewStruct1 WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Initializer for @ref WGPUPrefixNewStruct1.
+ */
+#define WGPU_PREFIX_NEW_STRUCT1_INIT _wgpu_MAKE_INIT_STRUCT(WGPUPrefixNewStruct1, { \
+    /*.member1=*/WGPU_PREFIX_NEW_CONSTANT1 _wgpu_COMMA \
+    /*.member2=*/WGPU_NEW_CONSTANT2 _wgpu_COMMA \
+})
+
+/**
+ * New struct can be declared in the 'webgpu' namespace explicitly.
+ *
+ * Default values can be set using @ref WGPU_NEW_STRUCT2_INIT as initializer.
+ */
+typedef struct WGPUNewStruct2 {
+    WGPUChainedStruct * nextInChain;
+    /**
+     * The `INIT` macro sets this to @ref WGPU_PREFIX_NEW_STRUCT1_INIT.
+     */
+    WGPUPrefixNewStruct1 structMember;
+} WGPUNewStruct2 WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Initializer for @ref WGPUNewStruct2.
+ */
+#define WGPU_NEW_STRUCT2_INIT _wgpu_MAKE_INIT_STRUCT(WGPUNewStruct2, { \
+    /*.nextInChain=*/NULL _wgpu_COMMA \
+    /*.structMember=*/WGPU_PREFIX_NEW_STRUCT1_INIT _wgpu_COMMA \
+})
+
+/** @} */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(WGPU_SKIP_PROCS)
+// Global procs
+/**
+ * Proc pointer type for @ref wgpuPrefixNewFunction1:
+ * > @copydoc wgpuPrefixNewFunction1
+ */
+typedef void (*WGPUProcPrefixNewFunction1)() WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * Proc pointer type for @ref wgpuNewFunction2:
+ * > @copydoc wgpuNewFunction2
+ */
+typedef void (*WGPUProcNewFunction2)() WGPU_FUNCTION_ATTRIBUTE;
+
+// Procs of PrefixNewObject1
+/**
+ * Proc pointer type for @ref wgpuPrefixNewObject1NewMethod:
+ * > @copydoc wgpuPrefixNewObject1NewMethod
+ */
+typedef void (*WGPUProcPrefixNewObject1NewMethod)(WGPUPrefixNewObject1 newObject1) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * Proc pointer type for @ref wgpuPrefixNewObject1AddRef:
+ * > @copydoc wgpuPrefixNewObject1AddRef
+ */
+typedef void (*WGPUProcPrefixNewObject1AddRef)(WGPUPrefixNewObject1 newObject1) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * Proc pointer type for @ref wgpuPrefixNewObject1Release:
+ * > @copydoc wgpuPrefixNewObject1Release
+ */
+typedef void (*WGPUProcPrefixNewObject1Release)(WGPUPrefixNewObject1 newObject1) WGPU_FUNCTION_ATTRIBUTE;
+
+// Procs of NewObject2
+/**
+ * Proc pointer type for @ref wgpuNewObject2NewMethod:
+ * > @copydoc wgpuNewObject2NewMethod
+ */
+typedef void (*WGPUProcNewObject2NewMethod)(WGPUNewObject2 newObject2) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * Proc pointer type for @ref wgpuNewObject2AddRef:
+ * > @copydoc wgpuNewObject2AddRef
+ */
+typedef void (*WGPUProcNewObject2AddRef)(WGPUNewObject2 newObject2) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * Proc pointer type for @ref wgpuNewObject2Release:
+ * > @copydoc wgpuNewObject2Release
+ */
+typedef void (*WGPUProcNewObject2Release)(WGPUNewObject2 newObject2) WGPU_FUNCTION_ATTRIBUTE;
+
+// Procs of OldObject
+/**
+ * Proc pointer type for @ref wgpuOldObjectPrefixNewMethod1:
+ * > @copydoc wgpuOldObjectPrefixNewMethod1
+ */
+typedef void (*WGPUProcOldObjectPrefixNewMethod1)(WGPUOldObject oldObject) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * Proc pointer type for @ref wgpuOldObjectNewMethod2:
+ * > @copydoc wgpuOldObjectNewMethod2
+ */
+typedef void (*WGPUProcOldObjectNewMethod2)(WGPUOldObject oldObject) WGPU_FUNCTION_ATTRIBUTE;
+
+#endif  // !defined(WGPU_SKIP_PROCS)
+
+#if !defined(WGPU_SKIP_DECLARATIONS)
+/**
+ * \defgroup GlobalFunctions Global Functions
+ * \brief Functions that are not specific to an object.
+ *
+ * @{
+ */
+/**
+ * New function should have the namespace prefix in the name by default.
+ */
+WGPU_EXPORT void wgpuPrefixNewFunction1() WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * New function can be declared in the 'webgpu' namespace explicitly.
+ */
+WGPU_EXPORT void wgpuNewFunction2() WGPU_FUNCTION_ATTRIBUTE;
+
+/** @} */
+
+/**
+ * \defgroup Methods Methods
+ * \brief Functions that are relative to a specific object.
+ *
+ * @{
+ */
+
+/**
+ * \defgroup WGPUPrefixNewObject1Methods WGPUPrefixNewObject1 methods
+ * \brief Functions whose first argument has type WGPUPrefixNewObject1.
+ *
+ * @{
+ */
+/**
+ * Method on new object should not have the namespace prefix in the name by default.
+ */
+WGPU_EXPORT void wgpuPrefixNewObject1NewMethod(WGPUPrefixNewObject1 newObject1) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuPrefixNewObject1AddRef(WGPUPrefixNewObject1 newObject1) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuPrefixNewObject1Release(WGPUPrefixNewObject1 newObject1) WGPU_FUNCTION_ATTRIBUTE;
+/** @} */
+
+/**
+ * \defgroup WGPUNewObject2Methods WGPUNewObject2 methods
+ * \brief Functions whose first argument has type WGPUNewObject2.
+ *
+ * @{
+ */
+/**
+ * Method on new object should not have the namespace prefix in the name by default.
+ */
+WGPU_EXPORT void wgpuNewObject2NewMethod(WGPUNewObject2 newObject2) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuNewObject2AddRef(WGPUNewObject2 newObject2) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuNewObject2Release(WGPUNewObject2 newObject2) WGPU_FUNCTION_ATTRIBUTE;
+/** @} */
+
+/**
+ * \defgroup WGPUOldObjectMethods WGPUOldObject methods
+ * \brief Functions whose first argument has type WGPUOldObject.
+ *
+ * @{
+ */
+/**
+ * New method on old object should have the namespace prefix in the name by default.
+ */
+WGPU_EXPORT void wgpuOldObjectPrefixNewMethod1(WGPUOldObject oldObject) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * New method on old object can be declared in the 'webgpu' namespace explicitly.
+ */
+WGPU_EXPORT void wgpuOldObjectNewMethod2(WGPUOldObject oldObject) WGPU_FUNCTION_ATTRIBUTE;
+/** @} */
+
+/** @} */
+
+#endif  // !defined(WGPU_SKIP_DECLARATIONS)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // WEBGPU_EXTENSION_H_

--- a/webgpu.h
+++ b/webgpu.h
@@ -84,7 +84,6 @@
 #  endif
 #endif
 
-
 /**
  * \defgroup Constants Constants
  * \brief Constants.
@@ -106,7 +105,6 @@
 #define WGPU_WHOLE_MAP_SIZE (SIZE_MAX)
 #define WGPU_WHOLE_SIZE (UINT64_MAX)
 
-
 /** @} */
 
 /**
@@ -114,8 +112,6 @@
  *
  * @{
  */
-typedef uint64_t WGPUFlags;
-typedef uint32_t WGPUBool;
 
 /**
  * Nullable value defining a pointer+length view into a UTF-8 encoded string.
@@ -157,6 +153,8 @@ typedef struct WGPUStringView {
     /*.length=*/WGPU_STRLEN _wgpu_COMMA \
 })
 
+typedef uint64_t WGPUFlags;
+typedef uint32_t WGPUBool;
 
 /** @} */
 
@@ -192,8 +190,8 @@ typedef struct WGPUSurfaceImpl* WGPUSurface WGPU_OBJECT_ATTRIBUTE;
 typedef struct WGPUTextureImpl* WGPUTexture WGPU_OBJECT_ATTRIBUTE;
 typedef struct WGPUTextureViewImpl* WGPUTextureView WGPU_OBJECT_ATTRIBUTE;
 
-
 /** @} */
+
 // Structure forward declarations
 struct WGPUAdapterInfo;
 struct WGPUBindGroupEntry;
@@ -281,13 +279,13 @@ struct WGPURequestAdapterCallbackInfo;
 struct WGPURequestDeviceCallbackInfo;
 struct WGPUUncapturedErrorCallbackInfo;
 
-
 /**
  * \defgroup Enumerations Enumerations
  * \brief Enums.
  *
  * @{
  */
+
 typedef enum WGPUAdapterType {
     WGPUAdapterType_DiscreteGPU = 0x00000001,
     WGPUAdapterType_IntegratedGPU = 0x00000002,
@@ -1119,8 +1117,6 @@ typedef enum WGPUWaitStatus {
     WGPUWaitStatus_Error = 0x00000003,
     WGPUWaitStatus_Force32 = 0x7FFFFFFF
 } WGPUWaitStatus WGPU_ENUM_ATTRIBUTE;
-
-
 /** @} */
 
 /**
@@ -1129,6 +1125,7 @@ typedef enum WGPUWaitStatus {
  *
  * @{
  */
+
 /**
  * For reserved non-standard bitflag values, see @ref BitflagRegistry.
  */
@@ -1202,10 +1199,9 @@ static const WGPUTextureUsage WGPUTextureUsage_TextureBinding = 0x00000000000000
 static const WGPUTextureUsage WGPUTextureUsage_StorageBinding = 0x0000000000000008;
 static const WGPUTextureUsage WGPUTextureUsage_RenderAttachment = 0x0000000000000010;
 
-
 /** @} */
-typedef void (*WGPUProc)(void) WGPU_FUNCTION_ATTRIBUTE;
 
+typedef void (*WGPUProc)(void) WGPU_FUNCTION_ATTRIBUTE;
 
 /**
  * \defgroup Callbacks Callbacks
@@ -1213,6 +1209,7 @@ typedef void (*WGPUProc)(void) WGPU_FUNCTION_ATTRIBUTE;
  *
  * @{
  */
+
 /**
  * See also @ref CallbackError.
  *
@@ -1220,6 +1217,7 @@ typedef void (*WGPUProc)(void) WGPU_FUNCTION_ATTRIBUTE;
  * This parameter is @ref PassedWithoutOwnership.
  */
 typedef void (*WGPUBufferMapCallback)(WGPUMapAsyncStatus status, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
 /**
  * See also @ref CallbackError.
  *
@@ -1229,6 +1227,7 @@ typedef void (*WGPUBufferMapCallback)(WGPUMapAsyncStatus status, WGPUStringView 
  * This parameter is @ref PassedWithoutOwnership.
  */
 typedef void (*WGPUCompilationInfoCallback)(WGPUCompilationInfoRequestStatus status, struct WGPUCompilationInfo const * compilationInfo, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
 /**
  * See also @ref CallbackError.
  *
@@ -1236,6 +1235,7 @@ typedef void (*WGPUCompilationInfoCallback)(WGPUCompilationInfoRequestStatus sta
  * This parameter is @ref PassedWithOwnership.
  */
 typedef void (*WGPUCreateComputePipelineAsyncCallback)(WGPUCreatePipelineAsyncStatus status, WGPUComputePipeline pipeline, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
 /**
  * See also @ref CallbackError.
  *
@@ -1243,6 +1243,7 @@ typedef void (*WGPUCreateComputePipelineAsyncCallback)(WGPUCreatePipelineAsyncSt
  * This parameter is @ref PassedWithOwnership.
  */
 typedef void (*WGPUCreateRenderPipelineAsyncCallback)(WGPUCreatePipelineAsyncStatus status, WGPURenderPipeline pipeline, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
 /**
  * See also @ref CallbackError.
  *
@@ -1254,6 +1255,7 @@ typedef void (*WGPUCreateRenderPipelineAsyncCallback)(WGPUCreatePipelineAsyncSta
  * This parameter is @ref PassedWithoutOwnership.
  */
 typedef void (*WGPUDeviceLostCallback)(WGPUDevice const * device, WGPUDeviceLostReason reason, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
 /**
  * See also @ref CallbackError.
  *
@@ -1272,10 +1274,12 @@ typedef void (*WGPUDeviceLostCallback)(WGPUDevice const * device, WGPUDeviceLost
  * This parameter is @ref PassedWithoutOwnership.
  */
 typedef void (*WGPUPopErrorScopeCallback)(WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
 /**
  * See also @ref CallbackError.
  */
 typedef void (*WGPUQueueWorkDoneCallback)(WGPUQueueWorkDoneStatus status, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
 /**
  * See also @ref CallbackError.
  *
@@ -1286,6 +1290,7 @@ typedef void (*WGPUQueueWorkDoneCallback)(WGPUQueueWorkDoneStatus status, WGPU_N
  * This parameter is @ref PassedWithoutOwnership.
  */
 typedef void (*WGPURequestAdapterCallback)(WGPURequestAdapterStatus status, WGPUAdapter adapter, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
 /**
  * See also @ref CallbackError.
  *
@@ -1296,6 +1301,7 @@ typedef void (*WGPURequestAdapterCallback)(WGPURequestAdapterStatus status, WGPU
  * This parameter is @ref PassedWithoutOwnership.
  */
 typedef void (*WGPURequestDeviceCallback)(WGPURequestDeviceStatus status, WGPUDevice device, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+
 /**
  * See also @ref CallbackError.
  *
@@ -1331,11 +1337,12 @@ typedef struct WGPUChainedStruct {
  */
 
 /**
- * \defgroup WGPUCallbackInfo Callback Info Structs
+ * \defgroup CallbackInfoStructs Callback Info Structs
  * \brief Callback info structures that are used in asynchronous functions.
  *
  * @{
  */
+
 typedef struct WGPUBufferMapCallbackInfo {
     WGPUChainedStruct * nextInChain;
     /**
@@ -4447,7 +4454,7 @@ extern "C" {
 #endif
 
 #if !defined(WGPU_SKIP_PROCS)
-
+// Global procs
 /**
  * Proc pointer type for @ref wgpuCreateInstance:
  * > @copydoc wgpuCreateInstance
@@ -4463,6 +4470,7 @@ typedef WGPUStatus (*WGPUProcGetInstanceCapabilities)(WGPUInstanceCapabilities *
  * > @copydoc wgpuGetProcAddress
  */
 typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUStringView procName) WGPU_FUNCTION_ATTRIBUTE;
+
 
 // Procs of Adapter
 /**
@@ -4491,12 +4499,12 @@ typedef WGPUBool (*WGPUProcAdapterHasFeature)(WGPUAdapter adapter, WGPUFeatureNa
  */
 typedef WGPUFuture (*WGPUProcAdapterRequestDevice)(WGPUAdapter adapter, WGPU_NULLABLE WGPUDeviceDescriptor const * descriptor, WGPURequestDeviceCallbackInfo callbackInfo) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuAdapterAddRef.
+ * Proc pointer type for @ref wgpuAdapterAddRef:
  * > @copydoc wgpuAdapterAddRef
  */
 typedef void (*WGPUProcAdapterAddRef)(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuAdapterRelease.
+ * Proc pointer type for @ref wgpuAdapterRelease:
  * > @copydoc wgpuAdapterRelease
  */
 typedef void (*WGPUProcAdapterRelease)(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;
@@ -4515,12 +4523,12 @@ typedef void (*WGPUProcAdapterInfoFreeMembers)(WGPUAdapterInfo adapterInfo) WGPU
  */
 typedef void (*WGPUProcBindGroupSetLabel)(WGPUBindGroup bindGroup, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuBindGroupAddRef.
+ * Proc pointer type for @ref wgpuBindGroupAddRef:
  * > @copydoc wgpuBindGroupAddRef
  */
 typedef void (*WGPUProcBindGroupAddRef)(WGPUBindGroup bindGroup) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuBindGroupRelease.
+ * Proc pointer type for @ref wgpuBindGroupRelease:
  * > @copydoc wgpuBindGroupRelease
  */
 typedef void (*WGPUProcBindGroupRelease)(WGPUBindGroup bindGroup) WGPU_FUNCTION_ATTRIBUTE;
@@ -4532,12 +4540,12 @@ typedef void (*WGPUProcBindGroupRelease)(WGPUBindGroup bindGroup) WGPU_FUNCTION_
  */
 typedef void (*WGPUProcBindGroupLayoutSetLabel)(WGPUBindGroupLayout bindGroupLayout, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuBindGroupLayoutAddRef.
+ * Proc pointer type for @ref wgpuBindGroupLayoutAddRef:
  * > @copydoc wgpuBindGroupLayoutAddRef
  */
 typedef void (*WGPUProcBindGroupLayoutAddRef)(WGPUBindGroupLayout bindGroupLayout) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuBindGroupLayoutRelease.
+ * Proc pointer type for @ref wgpuBindGroupLayoutRelease:
  * > @copydoc wgpuBindGroupLayoutRelease
  */
 typedef void (*WGPUProcBindGroupLayoutRelease)(WGPUBindGroupLayout bindGroupLayout) WGPU_FUNCTION_ATTRIBUTE;
@@ -4599,12 +4607,12 @@ typedef void (*WGPUProcBufferUnmap)(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
  */
 typedef WGPUStatus (*WGPUProcBufferWriteMappedRange)(WGPUBuffer buffer, size_t offset, void const * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuBufferAddRef.
+ * Proc pointer type for @ref wgpuBufferAddRef:
  * > @copydoc wgpuBufferAddRef
  */
 typedef void (*WGPUProcBufferAddRef)(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuBufferRelease.
+ * Proc pointer type for @ref wgpuBufferRelease:
  * > @copydoc wgpuBufferRelease
  */
 typedef void (*WGPUProcBufferRelease)(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
@@ -4616,12 +4624,12 @@ typedef void (*WGPUProcBufferRelease)(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE
  */
 typedef void (*WGPUProcCommandBufferSetLabel)(WGPUCommandBuffer commandBuffer, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuCommandBufferAddRef.
+ * Proc pointer type for @ref wgpuCommandBufferAddRef:
  * > @copydoc wgpuCommandBufferAddRef
  */
 typedef void (*WGPUProcCommandBufferAddRef)(WGPUCommandBuffer commandBuffer) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuCommandBufferRelease.
+ * Proc pointer type for @ref wgpuCommandBufferRelease:
  * > @copydoc wgpuCommandBufferRelease
  */
 typedef void (*WGPUProcCommandBufferRelease)(WGPUCommandBuffer commandBuffer) WGPU_FUNCTION_ATTRIBUTE;
@@ -4698,12 +4706,12 @@ typedef void (*WGPUProcCommandEncoderSetLabel)(WGPUCommandEncoder commandEncoder
  */
 typedef void (*WGPUProcCommandEncoderWriteTimestamp)(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t queryIndex) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuCommandEncoderAddRef.
+ * Proc pointer type for @ref wgpuCommandEncoderAddRef:
  * > @copydoc wgpuCommandEncoderAddRef
  */
 typedef void (*WGPUProcCommandEncoderAddRef)(WGPUCommandEncoder commandEncoder) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuCommandEncoderRelease.
+ * Proc pointer type for @ref wgpuCommandEncoderRelease:
  * > @copydoc wgpuCommandEncoderRelease
  */
 typedef void (*WGPUProcCommandEncoderRelease)(WGPUCommandEncoder commandEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -4755,12 +4763,12 @@ typedef void (*WGPUProcComputePassEncoderSetLabel)(WGPUComputePassEncoder comput
  */
 typedef void (*WGPUProcComputePassEncoderSetPipeline)(WGPUComputePassEncoder computePassEncoder, WGPUComputePipeline pipeline) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuComputePassEncoderAddRef.
+ * Proc pointer type for @ref wgpuComputePassEncoderAddRef:
  * > @copydoc wgpuComputePassEncoderAddRef
  */
 typedef void (*WGPUProcComputePassEncoderAddRef)(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuComputePassEncoderRelease.
+ * Proc pointer type for @ref wgpuComputePassEncoderRelease:
  * > @copydoc wgpuComputePassEncoderRelease
  */
 typedef void (*WGPUProcComputePassEncoderRelease)(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -4777,12 +4785,12 @@ typedef WGPUBindGroupLayout (*WGPUProcComputePipelineGetBindGroupLayout)(WGPUCom
  */
 typedef void (*WGPUProcComputePipelineSetLabel)(WGPUComputePipeline computePipeline, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuComputePipelineAddRef.
+ * Proc pointer type for @ref wgpuComputePipelineAddRef:
  * > @copydoc wgpuComputePipelineAddRef
  */
 typedef void (*WGPUProcComputePipelineAddRef)(WGPUComputePipeline computePipeline) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuComputePipelineRelease.
+ * Proc pointer type for @ref wgpuComputePipelineRelease:
  * > @copydoc wgpuComputePipelineRelease
  */
 typedef void (*WGPUProcComputePipelineRelease)(WGPUComputePipeline computePipeline) WGPU_FUNCTION_ATTRIBUTE;
@@ -4909,12 +4917,12 @@ typedef void (*WGPUProcDevicePushErrorScope)(WGPUDevice device, WGPUErrorFilter 
  */
 typedef void (*WGPUProcDeviceSetLabel)(WGPUDevice device, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuDeviceAddRef.
+ * Proc pointer type for @ref wgpuDeviceAddRef:
  * > @copydoc wgpuDeviceAddRef
  */
 typedef void (*WGPUProcDeviceAddRef)(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuDeviceRelease.
+ * Proc pointer type for @ref wgpuDeviceRelease:
  * > @copydoc wgpuDeviceRelease
  */
 typedef void (*WGPUProcDeviceRelease)(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
@@ -4951,12 +4959,12 @@ typedef WGPUFuture (*WGPUProcInstanceRequestAdapter)(WGPUInstance instance, WGPU
  */
 typedef WGPUWaitStatus (*WGPUProcInstanceWaitAny)(WGPUInstance instance, size_t futureCount, WGPU_NULLABLE WGPUFutureWaitInfo * futures, uint64_t timeoutNS) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuInstanceAddRef.
+ * Proc pointer type for @ref wgpuInstanceAddRef:
  * > @copydoc wgpuInstanceAddRef
  */
 typedef void (*WGPUProcInstanceAddRef)(WGPUInstance instance) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuInstanceRelease.
+ * Proc pointer type for @ref wgpuInstanceRelease:
  * > @copydoc wgpuInstanceRelease
  */
 typedef void (*WGPUProcInstanceRelease)(WGPUInstance instance) WGPU_FUNCTION_ATTRIBUTE;
@@ -4968,12 +4976,12 @@ typedef void (*WGPUProcInstanceRelease)(WGPUInstance instance) WGPU_FUNCTION_ATT
  */
 typedef void (*WGPUProcPipelineLayoutSetLabel)(WGPUPipelineLayout pipelineLayout, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuPipelineLayoutAddRef.
+ * Proc pointer type for @ref wgpuPipelineLayoutAddRef:
  * > @copydoc wgpuPipelineLayoutAddRef
  */
 typedef void (*WGPUProcPipelineLayoutAddRef)(WGPUPipelineLayout pipelineLayout) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuPipelineLayoutRelease.
+ * Proc pointer type for @ref wgpuPipelineLayoutRelease:
  * > @copydoc wgpuPipelineLayoutRelease
  */
 typedef void (*WGPUProcPipelineLayoutRelease)(WGPUPipelineLayout pipelineLayout) WGPU_FUNCTION_ATTRIBUTE;
@@ -5000,12 +5008,12 @@ typedef WGPUQueryType (*WGPUProcQuerySetGetType)(WGPUQuerySet querySet) WGPU_FUN
  */
 typedef void (*WGPUProcQuerySetSetLabel)(WGPUQuerySet querySet, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuQuerySetAddRef.
+ * Proc pointer type for @ref wgpuQuerySetAddRef:
  * > @copydoc wgpuQuerySetAddRef
  */
 typedef void (*WGPUProcQuerySetAddRef)(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuQuerySetRelease.
+ * Proc pointer type for @ref wgpuQuerySetRelease:
  * > @copydoc wgpuQuerySetRelease
  */
 typedef void (*WGPUProcQuerySetRelease)(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIBUTE;
@@ -5037,12 +5045,12 @@ typedef void (*WGPUProcQueueWriteBuffer)(WGPUQueue queue, WGPUBuffer buffer, uin
  */
 typedef void (*WGPUProcQueueWriteTexture)(WGPUQueue queue, WGPUTexelCopyTextureInfo const * destination, void const * data, size_t dataSize, WGPUTexelCopyBufferLayout const * dataLayout, WGPUExtent3D const * writeSize) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuQueueAddRef.
+ * Proc pointer type for @ref wgpuQueueAddRef:
  * > @copydoc wgpuQueueAddRef
  */
 typedef void (*WGPUProcQueueAddRef)(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuQueueRelease.
+ * Proc pointer type for @ref wgpuQueueRelease:
  * > @copydoc wgpuQueueRelease
  */
 typedef void (*WGPUProcQueueRelease)(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
@@ -5054,12 +5062,12 @@ typedef void (*WGPUProcQueueRelease)(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
  */
 typedef void (*WGPUProcRenderBundleSetLabel)(WGPURenderBundle renderBundle, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuRenderBundleAddRef.
+ * Proc pointer type for @ref wgpuRenderBundleAddRef:
  * > @copydoc wgpuRenderBundleAddRef
  */
 typedef void (*WGPUProcRenderBundleAddRef)(WGPURenderBundle renderBundle) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuRenderBundleRelease.
+ * Proc pointer type for @ref wgpuRenderBundleRelease:
  * > @copydoc wgpuRenderBundleRelease
  */
 typedef void (*WGPUProcRenderBundleRelease)(WGPURenderBundle renderBundle) WGPU_FUNCTION_ATTRIBUTE;
@@ -5131,12 +5139,12 @@ typedef void (*WGPUProcRenderBundleEncoderSetPipeline)(WGPURenderBundleEncoder r
  */
 typedef void (*WGPUProcRenderBundleEncoderSetVertexBuffer)(WGPURenderBundleEncoder renderBundleEncoder, uint32_t slot, WGPU_NULLABLE WGPUBuffer buffer, uint64_t offset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuRenderBundleEncoderAddRef.
+ * Proc pointer type for @ref wgpuRenderBundleEncoderAddRef:
  * > @copydoc wgpuRenderBundleEncoderAddRef
  */
 typedef void (*WGPUProcRenderBundleEncoderAddRef)(WGPURenderBundleEncoder renderBundleEncoder) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuRenderBundleEncoderRelease.
+ * Proc pointer type for @ref wgpuRenderBundleEncoderRelease:
  * > @copydoc wgpuRenderBundleEncoderRelease
  */
 typedef void (*WGPUProcRenderBundleEncoderRelease)(WGPURenderBundleEncoder renderBundleEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -5243,12 +5251,12 @@ typedef void (*WGPUProcRenderPassEncoderSetVertexBuffer)(WGPURenderPassEncoder r
  */
 typedef void (*WGPUProcRenderPassEncoderSetViewport)(WGPURenderPassEncoder renderPassEncoder, float x, float y, float width, float height, float minDepth, float maxDepth) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuRenderPassEncoderAddRef.
+ * Proc pointer type for @ref wgpuRenderPassEncoderAddRef:
  * > @copydoc wgpuRenderPassEncoderAddRef
  */
 typedef void (*WGPUProcRenderPassEncoderAddRef)(WGPURenderPassEncoder renderPassEncoder) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuRenderPassEncoderRelease.
+ * Proc pointer type for @ref wgpuRenderPassEncoderRelease:
  * > @copydoc wgpuRenderPassEncoderRelease
  */
 typedef void (*WGPUProcRenderPassEncoderRelease)(WGPURenderPassEncoder renderPassEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -5265,12 +5273,12 @@ typedef WGPUBindGroupLayout (*WGPUProcRenderPipelineGetBindGroupLayout)(WGPURend
  */
 typedef void (*WGPUProcRenderPipelineSetLabel)(WGPURenderPipeline renderPipeline, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuRenderPipelineAddRef.
+ * Proc pointer type for @ref wgpuRenderPipelineAddRef:
  * > @copydoc wgpuRenderPipelineAddRef
  */
 typedef void (*WGPUProcRenderPipelineAddRef)(WGPURenderPipeline renderPipeline) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuRenderPipelineRelease.
+ * Proc pointer type for @ref wgpuRenderPipelineRelease:
  * > @copydoc wgpuRenderPipelineRelease
  */
 typedef void (*WGPUProcRenderPipelineRelease)(WGPURenderPipeline renderPipeline) WGPU_FUNCTION_ATTRIBUTE;
@@ -5282,12 +5290,12 @@ typedef void (*WGPUProcRenderPipelineRelease)(WGPURenderPipeline renderPipeline)
  */
 typedef void (*WGPUProcSamplerSetLabel)(WGPUSampler sampler, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuSamplerAddRef.
+ * Proc pointer type for @ref wgpuSamplerAddRef:
  * > @copydoc wgpuSamplerAddRef
  */
 typedef void (*WGPUProcSamplerAddRef)(WGPUSampler sampler) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuSamplerRelease.
+ * Proc pointer type for @ref wgpuSamplerRelease:
  * > @copydoc wgpuSamplerRelease
  */
 typedef void (*WGPUProcSamplerRelease)(WGPUSampler sampler) WGPU_FUNCTION_ATTRIBUTE;
@@ -5304,12 +5312,12 @@ typedef WGPUFuture (*WGPUProcShaderModuleGetCompilationInfo)(WGPUShaderModule sh
  */
 typedef void (*WGPUProcShaderModuleSetLabel)(WGPUShaderModule shaderModule, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuShaderModuleAddRef.
+ * Proc pointer type for @ref wgpuShaderModuleAddRef:
  * > @copydoc wgpuShaderModuleAddRef
  */
 typedef void (*WGPUProcShaderModuleAddRef)(WGPUShaderModule shaderModule) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuShaderModuleRelease.
+ * Proc pointer type for @ref wgpuShaderModuleRelease:
  * > @copydoc wgpuShaderModuleRelease
  */
 typedef void (*WGPUProcShaderModuleRelease)(WGPUShaderModule shaderModule) WGPU_FUNCTION_ATTRIBUTE;
@@ -5360,12 +5368,12 @@ typedef void (*WGPUProcSurfaceSetLabel)(WGPUSurface surface, WGPUStringView labe
  */
 typedef void (*WGPUProcSurfaceUnconfigure)(WGPUSurface surface) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuSurfaceAddRef.
+ * Proc pointer type for @ref wgpuSurfaceAddRef:
  * > @copydoc wgpuSurfaceAddRef
  */
 typedef void (*WGPUProcSurfaceAddRef)(WGPUSurface surface) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuSurfaceRelease.
+ * Proc pointer type for @ref wgpuSurfaceRelease:
  * > @copydoc wgpuSurfaceRelease
  */
 typedef void (*WGPUProcSurfaceRelease)(WGPUSurface surface) WGPU_FUNCTION_ATTRIBUTE;
@@ -5434,12 +5442,12 @@ typedef uint32_t (*WGPUProcTextureGetWidth)(WGPUTexture texture) WGPU_FUNCTION_A
  */
 typedef void (*WGPUProcTextureSetLabel)(WGPUTexture texture, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuTextureAddRef.
+ * Proc pointer type for @ref wgpuTextureAddRef:
  * > @copydoc wgpuTextureAddRef
  */
 typedef void (*WGPUProcTextureAddRef)(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuTextureRelease.
+ * Proc pointer type for @ref wgpuTextureRelease:
  * > @copydoc wgpuTextureRelease
  */
 typedef void (*WGPUProcTextureRelease)(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
@@ -5451,12 +5459,12 @@ typedef void (*WGPUProcTextureRelease)(WGPUTexture texture) WGPU_FUNCTION_ATTRIB
  */
 typedef void (*WGPUProcTextureViewSetLabel)(WGPUTextureView textureView, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuTextureViewAddRef.
+ * Proc pointer type for @ref wgpuTextureViewAddRef:
  * > @copydoc wgpuTextureViewAddRef
  */
 typedef void (*WGPUProcTextureViewAddRef)(WGPUTextureView textureView) WGPU_FUNCTION_ATTRIBUTE;
 /**
- * Proc pointer type for @ref wgpuTextureViewRelease.
+ * Proc pointer type for @ref wgpuTextureViewRelease:
  * > @copydoc wgpuTextureViewRelease
  */
 typedef void (*WGPUProcTextureViewRelease)(WGPUTextureView textureView) WGPU_FUNCTION_ATTRIBUTE;
@@ -5535,8 +5543,6 @@ WGPU_EXPORT void wgpuAdapterAddRef(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuAdapterRelease(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUAdapterInfoMethods WGPUAdapterInfo methods
  * \brief Functions whose first argument has type WGPUAdapterInfo.
@@ -5544,12 +5550,10 @@ WGPU_EXPORT void wgpuAdapterRelease(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE
  * @{
  */
 /**
- * Frees array members of WGPUAdapterInfo which were allocated by the API.
+ * Frees members which were allocated by the API.
  */
 WGPU_EXPORT void wgpuAdapterInfoFreeMembers(WGPUAdapterInfo adapterInfo) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPUBindGroupMethods WGPUBindGroup methods
@@ -5562,8 +5566,6 @@ WGPU_EXPORT void wgpuBindGroupAddRef(WGPUBindGroup bindGroup) WGPU_FUNCTION_ATTR
 WGPU_EXPORT void wgpuBindGroupRelease(WGPUBindGroup bindGroup) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUBindGroupLayoutMethods WGPUBindGroupLayout methods
  * \brief Functions whose first argument has type WGPUBindGroupLayout.
@@ -5574,8 +5576,6 @@ WGPU_EXPORT void wgpuBindGroupLayoutSetLabel(WGPUBindGroupLayout bindGroupLayout
 WGPU_EXPORT void wgpuBindGroupLayoutAddRef(WGPUBindGroupLayout bindGroupLayout) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBindGroupLayoutRelease(WGPUBindGroupLayout bindGroupLayout) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPUBufferMethods WGPUBuffer methods
@@ -5679,8 +5679,6 @@ WGPU_EXPORT void wgpuBufferAddRef(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBufferRelease(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUCommandBufferMethods WGPUCommandBuffer methods
  * \brief Functions whose first argument has type WGPUCommandBuffer.
@@ -5691,8 +5689,6 @@ WGPU_EXPORT void wgpuCommandBufferSetLabel(WGPUCommandBuffer commandBuffer, WGPU
 WGPU_EXPORT void wgpuCommandBufferAddRef(WGPUCommandBuffer commandBuffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuCommandBufferRelease(WGPUCommandBuffer commandBuffer) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPUCommandEncoderMethods WGPUCommandEncoder methods
@@ -5730,8 +5726,6 @@ WGPU_EXPORT void wgpuCommandEncoderAddRef(WGPUCommandEncoder commandEncoder) WGP
 WGPU_EXPORT void wgpuCommandEncoderRelease(WGPUCommandEncoder commandEncoder) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUComputePassEncoderMethods WGPUComputePassEncoder methods
  * \brief Functions whose first argument has type WGPUComputePassEncoder.
@@ -5751,8 +5745,6 @@ WGPU_EXPORT void wgpuComputePassEncoderAddRef(WGPUComputePassEncoder computePass
 WGPU_EXPORT void wgpuComputePassEncoderRelease(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUComputePipelineMethods WGPUComputePipeline methods
  * \brief Functions whose first argument has type WGPUComputePipeline.
@@ -5768,8 +5760,6 @@ WGPU_EXPORT void wgpuComputePipelineSetLabel(WGPUComputePipeline computePipeline
 WGPU_EXPORT void wgpuComputePipelineAddRef(WGPUComputePipeline computePipeline) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePipelineRelease(WGPUComputePipeline computePipeline) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPUDeviceMethods WGPUDevice methods
@@ -5891,8 +5881,6 @@ WGPU_EXPORT void wgpuDeviceAddRef(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuDeviceRelease(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUInstanceMethods WGPUInstance methods
  * \brief Functions whose first argument has type WGPUInstance.
@@ -5932,8 +5920,6 @@ WGPU_EXPORT void wgpuInstanceAddRef(WGPUInstance instance) WGPU_FUNCTION_ATTRIBU
 WGPU_EXPORT void wgpuInstanceRelease(WGPUInstance instance) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUPipelineLayoutMethods WGPUPipelineLayout methods
  * \brief Functions whose first argument has type WGPUPipelineLayout.
@@ -5944,8 +5930,6 @@ WGPU_EXPORT void wgpuPipelineLayoutSetLabel(WGPUPipelineLayout pipelineLayout, W
 WGPU_EXPORT void wgpuPipelineLayoutAddRef(WGPUPipelineLayout pipelineLayout) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuPipelineLayoutRelease(WGPUPipelineLayout pipelineLayout) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPUQuerySetMethods WGPUQuerySet methods
@@ -5960,8 +5944,6 @@ WGPU_EXPORT void wgpuQuerySetSetLabel(WGPUQuerySet querySet, WGPUStringView labe
 WGPU_EXPORT void wgpuQuerySetAddRef(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQuerySetRelease(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPUQueueMethods WGPUQueue methods
@@ -5982,8 +5964,6 @@ WGPU_EXPORT void wgpuQueueAddRef(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueRelease(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPURenderBundleMethods WGPURenderBundle methods
  * \brief Functions whose first argument has type WGPURenderBundle.
@@ -5994,8 +5974,6 @@ WGPU_EXPORT void wgpuRenderBundleSetLabel(WGPURenderBundle renderBundle, WGPUStr
 WGPU_EXPORT void wgpuRenderBundleAddRef(WGPURenderBundle renderBundle) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleRelease(WGPURenderBundle renderBundle) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPURenderBundleEncoderMethods WGPURenderBundleEncoder methods
@@ -6023,8 +6001,6 @@ WGPU_EXPORT void wgpuRenderBundleEncoderSetVertexBuffer(WGPURenderBundleEncoder 
 WGPU_EXPORT void wgpuRenderBundleEncoderAddRef(WGPURenderBundleEncoder renderBundleEncoder) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderRelease(WGPURenderBundleEncoder renderBundleEncoder) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPURenderPassEncoderMethods WGPURenderPassEncoder methods
@@ -6065,8 +6041,6 @@ WGPU_EXPORT void wgpuRenderPassEncoderAddRef(WGPURenderPassEncoder renderPassEnc
 WGPU_EXPORT void wgpuRenderPassEncoderRelease(WGPURenderPassEncoder renderPassEncoder) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPURenderPipelineMethods WGPURenderPipeline methods
  * \brief Functions whose first argument has type WGPURenderPipeline.
@@ -6083,8 +6057,6 @@ WGPU_EXPORT void wgpuRenderPipelineAddRef(WGPURenderPipeline renderPipeline) WGP
 WGPU_EXPORT void wgpuRenderPipelineRelease(WGPURenderPipeline renderPipeline) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUSamplerMethods WGPUSampler methods
  * \brief Functions whose first argument has type WGPUSampler.
@@ -6095,8 +6067,6 @@ WGPU_EXPORT void wgpuSamplerSetLabel(WGPUSampler sampler, WGPUStringView label) 
 WGPU_EXPORT void wgpuSamplerAddRef(WGPUSampler sampler) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuSamplerRelease(WGPUSampler sampler) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPUShaderModuleMethods WGPUShaderModule methods
@@ -6110,8 +6080,6 @@ WGPU_EXPORT void wgpuShaderModuleAddRef(WGPUShaderModule shaderModule) WGPU_FUNC
 WGPU_EXPORT void wgpuShaderModuleRelease(WGPUShaderModule shaderModule) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUSupportedFeaturesMethods WGPUSupportedFeatures methods
  * \brief Functions whose first argument has type WGPUSupportedFeatures.
@@ -6119,12 +6087,10 @@ WGPU_EXPORT void wgpuShaderModuleRelease(WGPUShaderModule shaderModule) WGPU_FUN
  * @{
  */
 /**
- * Frees array members of WGPUSupportedFeatures which were allocated by the API.
+ * Frees members which were allocated by the API.
  */
 WGPU_EXPORT void wgpuSupportedFeaturesFreeMembers(WGPUSupportedFeatures supportedFeatures) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPUSupportedWGSLLanguageFeaturesMethods WGPUSupportedWGSLLanguageFeatures methods
@@ -6133,12 +6099,10 @@ WGPU_EXPORT void wgpuSupportedFeaturesFreeMembers(WGPUSupportedFeatures supporte
  * @{
  */
 /**
- * Frees array members of WGPUSupportedWGSLLanguageFeatures which were allocated by the API.
+ * Frees members which were allocated by the API.
  */
 WGPU_EXPORT void wgpuSupportedWGSLLanguageFeaturesFreeMembers(WGPUSupportedWGSLLanguageFeatures supportedWGSLLanguageFeatures) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPUSurfaceMethods WGPUSurface methods
@@ -6206,8 +6170,6 @@ WGPU_EXPORT void wgpuSurfaceAddRef(WGPUSurface surface) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuSurfaceRelease(WGPUSurface surface) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUSurfaceCapabilitiesMethods WGPUSurfaceCapabilities methods
  * \brief Functions whose first argument has type WGPUSurfaceCapabilities.
@@ -6215,12 +6177,10 @@ WGPU_EXPORT void wgpuSurfaceRelease(WGPUSurface surface) WGPU_FUNCTION_ATTRIBUTE
  * @{
  */
 /**
- * Frees array members of WGPUSurfaceCapabilities which were allocated by the API.
+ * Frees members which were allocated by the API.
  */
 WGPU_EXPORT void wgpuSurfaceCapabilitiesFreeMembers(WGPUSurfaceCapabilities surfaceCapabilities) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
-
 
 /**
  * \defgroup WGPUTextureMethods WGPUTexture methods
@@ -6247,8 +6207,6 @@ WGPU_EXPORT void wgpuTextureAddRef(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuTextureRelease(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
-
-
 /**
  * \defgroup WGPUTextureViewMethods WGPUTextureView methods
  * \brief Functions whose first argument has type WGPUTextureView.
@@ -6259,7 +6217,6 @@ WGPU_EXPORT void wgpuTextureViewSetLabel(WGPUTextureView textureView, WGPUString
 WGPU_EXPORT void wgpuTextureViewAddRef(WGPUTextureView textureView) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuTextureViewRelease(WGPUTextureView textureView) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
-
 
 /** @} */
 


### PR DESCRIPTION
Fixes: #212

Previous work was done in https://github.com/webgpu-native/webgpu-headers/pull/462, but this change improves on the prototype.

- Updates generator and template to use prefixes for extensions instead of suffixes.
- Adds new `Base` embedded struct in the Go representation of the YAML to facilitate name generation.
- Adds a series of new helpers in `gen.go` to use the new `Base` struct to generate names properly.
- Adds minimal extension YAML along to showcase generator results and updates Makefile for testing.
- Some minor formatting changes to the templates so that newlines are more consistent. This was much easier to verify in the smaller extension header.