### PR TITLE
[breaking] Add binding arrays to WGPUBindGroupLayoutEntry

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -3626,6 +3626,12 @@ typedef struct WGPUBindGroupLayoutEntry {
      */
     uint32_t binding;
     /**
+     * The number of bindings (size of the binding array) defined by this entry.
+     *
+     * The `INIT` macro sets this to `1`.
+     */
+    uint32_t bindingCount;
+    /**
      * The `INIT` macro sets this to @ref WGPUShaderStage_None.
      */
     WGPUShaderStage visibility;
@@ -3653,6 +3659,7 @@ typedef struct WGPUBindGroupLayoutEntry {
 #define WGPU_BIND_GROUP_LAYOUT_ENTRY_INIT _wgpu_MAKE_INIT_STRUCT(WGPUBindGroupLayoutEntry, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
     /*.binding=*/0 _wgpu_COMMA \
+    /*.bindingCount=*/1 _wgpu_COMMA \
     /*.visibility=*/WGPUShaderStage_None _wgpu_COMMA \
     /*.buffer=*/_wgpu_STRUCT_ZERO_INIT _wgpu_COMMA \
     /*.sampler=*/_wgpu_STRUCT_ZERO_INIT _wgpu_COMMA \

--- a/webgpu.h
+++ b/webgpu.h
@@ -3626,15 +3626,15 @@ typedef struct WGPUBindGroupLayoutEntry {
      */
     uint32_t binding;
     /**
-     * The number of bindings (size of the binding array) defined by this entry.
-     *
-     * The `INIT` macro sets this to `1`.
-     */
-    uint32_t bindingCount;
-    /**
      * The `INIT` macro sets this to @ref WGPUShaderStage_None.
      */
     WGPUShaderStage visibility;
+    /**
+     * If non-zero, this entry defines a binding array with this size.
+     *
+     * The `INIT` macro sets this to `0`.
+     */
+    uint32_t bindingArraySize;
     /**
      * The `INIT` macro sets this to zero (which sets the entry to `BindingNotUsed`).
      */
@@ -3659,8 +3659,8 @@ typedef struct WGPUBindGroupLayoutEntry {
 #define WGPU_BIND_GROUP_LAYOUT_ENTRY_INIT _wgpu_MAKE_INIT_STRUCT(WGPUBindGroupLayoutEntry, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
     /*.binding=*/0 _wgpu_COMMA \
-    /*.bindingCount=*/1 _wgpu_COMMA \
     /*.visibility=*/WGPUShaderStage_None _wgpu_COMMA \
+    /*.bindingArraySize=*/0 _wgpu_COMMA \
     /*.buffer=*/_wgpu_STRUCT_ZERO_INIT _wgpu_COMMA \
     /*.sampler=*/_wgpu_STRUCT_ZERO_INIT _wgpu_COMMA \
     /*.texture=*/_wgpu_STRUCT_ZERO_INIT _wgpu_COMMA \

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1655,6 +1655,11 @@ structs:
         doc: |
           TODO
         type: uint32
+      - name: binding_count
+        doc: |
+          The number of bindings (size of the binding array) defined by this entry.
+        type: uint32
+        default: 1
       - name: visibility
         doc: |
           TODO

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -1655,16 +1655,15 @@ structs:
         doc: |
           TODO
         type: uint32
-      - name: binding_count
-        doc: |
-          The number of bindings (size of the binding array) defined by this entry.
-        type: uint32
-        default: 1
       - name: visibility
         doc: |
           TODO
         type: bitflag.shader_stage
         default: none
+      - name: binding_array_size
+        doc: |
+          If non-zero, this entry defines a binding array with this size.
+        type: uint32
       - name: buffer
         doc: |
           TODO


### PR DESCRIPTION
Based on https://github.com/gpuweb/gpuweb/blob/main/proposals/sized-binding-arrays.md

- [x] but with: https://github.com/gpuweb/gpuweb/pull/5174

Fixes #387
(dawn issue https://crbug.com/415092021)