### PR TITLE
[technically breaking] Auto-destroy Device when the last ref is dropped

### DIFF
--- a/doc/articles/Ownership.md
+++ b/doc/articles/Ownership.md
@@ -28,7 +28,7 @@ Note also that some structs with `FreeMembers` functions may be used as both inp
 
 Unlike other destroyable objects, releasing the last (external) ref to a device causes it to be automatically destroyed (via @ref wgpuDeviceDestroy) if it isn't already lost or destroyed. Though the device object is no longer valid to use after releasing the last ref, this has some notable direct effects:
 
-- It destroy buffers, unmapping them, aborting any pending map requests, and preventing future ones.
+- Destroying a device destroys its buffers, which will unmap them, abort any pending map requests, and prevent future map requests.
 - It fires the DeviceLost event (which will call the registered callback at some point, depending on its @ref WGPUCallbackMode).
     - Because the device's last ref has already been released, DeviceLost callbacks triggered in this way will *not* receive a pointer to the device object. This is still true if the callback was triggered *during* the release of the last ref (via @ref WGPUCallbackMode_AllowSpontaneous).
 

--- a/doc/articles/Ownership.md
+++ b/doc/articles/Ownership.md
@@ -26,10 +26,11 @@ Note also that some structs with `FreeMembers` functions may be used as both inp
 
 ## Releasing a Device object {#DeviceRelease}
 
-Unlike other destroyable objects, releasing the last (external) ref to a device causes it to be automatically destroyed (via @ref wgpuDeviceDestroy). Though the device object is no longer valid to use after dropping the last ref, this has some direct effects:
+Unlike other destroyable objects, releasing the last (external) ref to a device causes it to be automatically destroyed (via @ref wgpuDeviceDestroy) if it isn't already lost or destroyed. Though the device object is no longer valid to use after releasing the last ref, this has some notable direct effects:
 
-- Buffers are destroyed, aborting any pending map requests, and preventing future ones.
-- The @ref WGPUDevice object passed to @ref WGPUDeviceLostCallback is still a valid pointer, but since the refcount has reached 0, the object may not be used for any API operation.
+- It destroy buffers, aborting any pending map requests and preventing future ones.
+- It fires the DeviceLost event (which will call the registered callback at some point, depending on its @ref WGPUCallbackMode).
+    - Because the device's last ref has already been released, DeviceLost callbacks triggered in this way will *not* receive a pointer to the device object. This is still true if the callback was triggered *during* the release of the last ref (via @ref WGPUCallbackMode_AllowSpontaneous).
 
 ## Callback Arguments {#CallbackArgs}
 

--- a/doc/articles/Ownership.md
+++ b/doc/articles/Ownership.md
@@ -24,6 +24,13 @@ Note that such functions will *not* free any previously-allocated data: overwrit
 
 Note also that some structs with `FreeMembers` functions may be used as both inputs and outputs. In this case `FreeMembers` must only be used if the member allocations were made by the `webgpu.h` implementation (as an output), not if they were made by the application (as an input).
 
+## Releasing a Device object {#DeviceRelease}
+
+Unlike other destroyable objects, releasing the last (external) ref to a device causes it to be automatically destroyed (via @ref wgpuDeviceDestroy). Though the device object is no longer valid to use after dropping the last ref, this has some direct effects:
+
+- Buffers are destroyed, aborting any pending map requests, and preventing future ones.
+- The @ref WGPUDevice object passed to @ref WGPUDeviceLostCallback is still a valid pointer, but since the refcount has reached 0, the object may not be used for any API operation.
+
 ## Callback Arguments {#CallbackArgs}
 
 Output arguments passed from the API to application callbacks include objects and message strings, which are passed to most callbacks.

--- a/doc/articles/Ownership.md
+++ b/doc/articles/Ownership.md
@@ -28,7 +28,7 @@ Note also that some structs with `FreeMembers` functions may be used as both inp
 
 Unlike other destroyable objects, releasing the last (external) ref to a device causes it to be automatically destroyed (via @ref wgpuDeviceDestroy) if it isn't already lost or destroyed. Though the device object is no longer valid to use after releasing the last ref, this has some notable direct effects:
 
-- It destroy buffers, aborting any pending map requests and preventing future ones.
+- It destroy buffers, unmapping them, aborting any pending map requests, and preventing future ones.
 - It fires the DeviceLost event (which will call the registered callback at some point, depending on its @ref WGPUCallbackMode).
     - Because the device's last ref has already been released, DeviceLost callbacks triggered in this way will *not* receive a pointer to the device object. This is still true if the callback was triggered *during* the release of the last ref (via @ref WGPUCallbackMode_AllowSpontaneous).
 

--- a/webgpu.h
+++ b/webgpu.h
@@ -187,6 +187,12 @@ typedef struct WGPUCommandBufferImpl* WGPUCommandBuffer WGPU_OBJECT_ATTRIBUTE;
 typedef struct WGPUCommandEncoderImpl* WGPUCommandEncoder WGPU_OBJECT_ATTRIBUTE;
 typedef struct WGPUComputePassEncoderImpl* WGPUComputePassEncoder WGPU_OBJECT_ATTRIBUTE;
 typedef struct WGPUComputePipelineImpl* WGPUComputePipeline WGPU_OBJECT_ATTRIBUTE;
+/**
+ * TODO
+ *
+ * Releasing the last ref to a `WGPUDevice` also calls @ref wgpuDeviceDestroy.
+ * For more info, see @ref DeviceRelease.
+ */
 typedef struct WGPUDeviceImpl* WGPUDevice WGPU_OBJECT_ATTRIBUTE;
 typedef struct WGPUInstanceImpl* WGPUInstance WGPU_OBJECT_ATTRIBUTE;
 typedef struct WGPUPipelineLayoutImpl* WGPUPipelineLayout WGPU_OBJECT_ATTRIBUTE;
@@ -1263,7 +1269,10 @@ typedef void (*WGPUCreateRenderPipelineAsyncCallback)(WGPUCreatePipelineAsyncSta
  * See also @ref CallbackError.
  *
  * @param device
- * Reference to the device which was lost. If, and only if, the `reason` is @ref WGPUDeviceLostReason_FailedCreation, this is a non-null pointer to a null @ref WGPUDevice.
+ * Pointer to the device which was lost. This is always a non-null pointer.
+ * The pointed-to @ref WGPUDevice will be null if, and only if, either:
+ * (1) The `reason` is @ref WGPUDeviceLostReason_FailedCreation.
+ * (2) The last ref of the device has been released (or is being released).
  * This parameter is @ref PassedWithoutOwnership.
  *
  * @param message

--- a/webgpu.h
+++ b/webgpu.h
@@ -1272,7 +1272,7 @@ typedef void (*WGPUCreateRenderPipelineAsyncCallback)(WGPUCreatePipelineAsyncSta
  * Pointer to the device which was lost. This is always a non-null pointer.
  * The pointed-to @ref WGPUDevice will be null if, and only if, either:
  * (1) The `reason` is @ref WGPUDeviceLostReason_FailedCreation.
- * (2) The last ref of the device has been released (or is being released).
+ * (2) The last ref of the device has been (or is being) released: see @ref DeviceRelease.
  * This parameter is @ref PassedWithoutOwnership.
  *
  * @param message

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -3343,7 +3343,10 @@ callbacks:
     args:
       - name: device
         doc: |
-          Reference to the device which was lost. If, and only if, the `reason` is @ref WGPUDeviceLostReason_FailedCreation, this is a non-null pointer to a null @ref WGPUDevice.
+          Pointer to the device which was lost. This is always a non-null pointer.
+          The pointed-to @ref WGPUDevice will be null if, and only if, either:
+          (1) The `reason` is @ref WGPUDeviceLostReason_FailedCreation.
+          (2) The last ref of the device has been released (or is being released).
         type: object.device
         pointer: immutable
         passed_with_ownership: false

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -4049,6 +4049,9 @@ objects:
   - name: device
     doc: |
       TODO
+
+      Releasing the last ref to a `WGPUDevice` also calls @ref wgpuDeviceDestroy.
+      For more info, see @ref DeviceRelease.
     methods:
       - name: create_bind_group
         doc: |

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -3346,7 +3346,7 @@ callbacks:
           Pointer to the device which was lost. This is always a non-null pointer.
           The pointed-to @ref WGPUDevice will be null if, and only if, either:
           (1) The `reason` is @ref WGPUDeviceLostReason_FailedCreation.
-          (2) The last ref of the device has been released (or is being released).
+          (2) The last ref of the device has been (or is being) released: see @ref DeviceRelease.
         type: object.device
         pointer: immutable
         passed_with_ownership: false


### PR DESCRIPTION
This is _slightly_ different from Dawn's current implementation, in the DeviceLost callback behavior. Not sure about wgpu-native but don't think it will be a significant change there either.

Fixes #514
Fixes #531
(dawn issue https://crbug.com/415094789, obsoletes https://crbug.com/409086866)