### PR TITLE
Remove WGPUFeatureName_Undefined

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -555,10 +555,6 @@ typedef enum WGPUFeatureLevel {
 } WGPUFeatureLevel WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUFeatureName {
-    /**
-     * `0`.
-     */
-    WGPUFeatureName_Undefined = 0x00000000,
     WGPUFeatureName_DepthClipControl = 0x00000001,
     WGPUFeatureName_Depth32FloatStencil8 = 0x00000002,
     WGPUFeatureName_TimestampQuery = 0x00000003,

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -427,9 +427,7 @@ enums:
     doc: |
       TODO
     entries:
-      - name: undefined
-        doc: |
-          TODO
+      - null
       - name: depth_clip_control
         doc: |
           TODO


### PR DESCRIPTION
We decided that we would not name this:
https://github.com/webgpu-native/webgpu-headers/issues/45#issuecomment-1776319835

But I missed it in #364.

Technically breaking, but since it didn't do anything, any references to it are going to be trivial (e.g. `case` statements).

Issue: #45
(no dawn bug, dawn already doesn't have it)