### PR TITLE
Rename Feature/Limit to DeviceFeature/DeviceLimit

### DIFF
--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -81,7 +81,7 @@
  *
  * @{
  */
-
+{{ if eq .Name "webgpu"}}
 /**
  * 'True' value of @ref WGPUBool.
  *
@@ -96,12 +96,72 @@
  * `stdbool.h` or C++) casts to the same value.
  */
 #define WGPU_FALSE (UINT32_C(0))
-{{-   range .Constants}}
-{{-     MComment .Doc 0}}
+{{- end }}
+{{- range .Constants}}
+{{-   MComment .Doc 0}}
 #define WGPU_{{ConstantCaseName .Base}} ({{.Value | CValue}})
-{{-   end}}
+{{- end}}
 
 /** @} */
+
+{{ if eq .Name "webgpu" -}}
+/**
+ * \defgroup Aliases Aliases
+ * \brief Deprecated aliases for other definitions.
+ *
+ * @{
+ */
+
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName WGPUDeviceFeatureName
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_DepthClipControl WGPUDeviceFeatureName_DepthClipControl
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_Depth32FloatStencil8 WGPUDeviceFeatureName_Depth32FloatStencil8
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TimestampQuery WGPUDeviceFeatureName_TimestampQuery
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TextureCompressionBC WGPUDeviceFeatureName_TextureCompressionBC
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TextureCompressionBCSliced3D WGPUDeviceFeatureName_TextureCompressionBCSliced3D
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TextureCompressionETC2 WGPUDeviceFeatureName_TextureCompressionETC2
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TextureCompressionASTC WGPUDeviceFeatureName_TextureCompressionASTC
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TextureCompressionASTCSliced3D WGPUDeviceFeatureName_TextureCompressionASTCSliced3D
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_IndirectFirstInstance WGPUDeviceFeatureName_IndirectFirstInstance
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_ShaderF16 WGPUDeviceFeatureName_ShaderF16
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_RG11B10UfloatRenderable WGPUDeviceFeatureName_RG11B10UfloatRenderable
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_BGRA8UnormStorage WGPUDeviceFeatureName_BGRA8UnormStorage
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_Float32Filterable WGPUDeviceFeatureName_Float32Filterable
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_Float32Blendable WGPUDeviceFeatureName_Float32Blendable
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_ClipDistances WGPUDeviceFeatureName_ClipDistances
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_DualSourceBlending WGPUDeviceFeatureName_DualSourceBlending
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_Subgroups WGPUDeviceFeatureName_Subgroups
+
+/** @deprecated alias for the new, more specific struct name. */
+#define WGPULimits WGPUDeviceLimits
+/** @deprecated alias for the new, more specific struct init macro name. */
+#define WGPU_LIMITS_INIT WGPU_DEVICE_LIMITS_INIT
+
+/** @deprecated alias for the new, more specific struct name. */
+#define WGPUSupportedFeatures WGPUSupportedDeviceFeatures
+/** @deprecated alias for the new, more specific struct init macro name. */
+#define WGPU_SUPPORTED_FEATURES_INIT WGPU_SUPPORTED_DEVICE_FEATURES_INIT
+
+/** @} */
+
+{{ end -}}
 
 /**
  * \defgroup UtilityTypes Utility Types

--- a/gen/cheader.tmpl
+++ b/gen/cheader.tmpl
@@ -25,6 +25,10 @@
 #    define WGPU_EXPORT
 #endif  // defined(WGPU_SHARED_LIBRARY)
 
+#if !defined(WGPU_DISABLE_DEPRECATED_ALIASES)
+#define WGPU_DISABLE_DEPRECATED_ALIASES 0
+#endif
+
 #if !defined(WGPU_OBJECT_ATTRIBUTE)
 #define WGPU_OBJECT_ATTRIBUTE
 #endif
@@ -111,6 +115,7 @@
  *
  * @{
  */
+#if !WGPU_DISABLE_DEPRECATED_ALIASES
 
 /** @deprecated alias for the new, more specific enum name. */
 #define WGPUFeatureName WGPUDeviceFeatureName
@@ -159,6 +164,7 @@
 /** @deprecated alias for the new, more specific struct init macro name. */
 #define WGPU_SUPPORTED_FEATURES_INIT WGPU_SUPPORTED_DEVICE_FEATURES_INIT
 
+#endif // !WGPU_DISABLE_DEPRECATED_ALIASES
 /** @} */
 
 {{ end -}}

--- a/tests/compile/main.inl
+++ b/tests/compile/main.inl
@@ -33,6 +33,11 @@ int main(void) {
         uint64_t y = a.maxBufferSize = WGPU_LIMIT_U64_UNDEFINED;
     }
     {
+        WGPUDeviceLimits a;
+        uint32_t x = a.maxTextureDimension2D = WGPU_LIMIT_U32_UNDEFINED;
+        uint64_t y = a.maxBufferSize = WGPU_LIMIT_U64_UNDEFINED;
+    }
+    {
         WGPUPassTimestampWrites a;
         a.beginningOfPassWriteIndex = WGPU_QUERY_SET_INDEX_UNDEFINED;
         a.endOfPassWriteIndex = WGPU_QUERY_SET_INDEX_UNDEFINED;
@@ -75,6 +80,7 @@ int main(void) {
     { WGPURequestAdapterCallbackInfo x = WGPU_REQUEST_ADAPTER_CALLBACK_INFO_INIT; }
     { WGPURequestDeviceCallbackInfo x = WGPU_REQUEST_DEVICE_CALLBACK_INFO_INIT; }
     { WGPUUncapturedErrorCallbackInfo x = WGPU_UNCAPTURED_ERROR_CALLBACK_INFO_INIT; }
+
     { WGPUAdapterInfo x = WGPU_ADAPTER_INFO_INIT; }
     { WGPUBindGroupEntry x = WGPU_BIND_GROUP_ENTRY_INIT; }
     { WGPUBlendComponent x = WGPU_BLEND_COMPONENT_INIT; }
@@ -85,6 +91,7 @@ int main(void) {
     { WGPUCommandEncoderDescriptor x = WGPU_COMMAND_ENCODER_DESCRIPTOR_INIT; }
     { WGPUCompilationMessage x = WGPU_COMPILATION_MESSAGE_INIT; }
     { WGPUConstantEntry x = WGPU_CONSTANT_ENTRY_INIT; }
+    { WGPUDeviceLimits x = WGPU_DEVICE_LIMITS_INIT; }
     { WGPUFuture x = WGPU_FUTURE_INIT; }
     { WGPUInstanceLimits x = WGPU_INSTANCE_LIMITS_INIT; }
     { WGPULimits x = WGPU_LIMITS_INIT; }
@@ -106,6 +113,7 @@ int main(void) {
     { WGPUShaderSourceWGSL x = WGPU_SHADER_SOURCE_WGSL_INIT; }
     { WGPUStencilFaceState x = WGPU_STENCIL_FACE_STATE_INIT; }
     { WGPUStorageTextureBindingLayout x = WGPU_STORAGE_TEXTURE_BINDING_LAYOUT_INIT; }
+    { WGPUSupportedDeviceFeatures x = WGPU_SUPPORTED_DEVICE_FEATURES_INIT; }
     { WGPUSupportedFeatures x = WGPU_SUPPORTED_FEATURES_INIT; }
     { WGPUSupportedInstanceFeatures x = WGPU_SUPPORTED_INSTANCE_FEATURES_INIT; }
     { WGPUSupportedWGSLLanguageFeatures x = WGPU_SUPPORTED_WGSL_LANGUAGE_FEATURES_INIT; }

--- a/tests/compile/main.inl
+++ b/tests/compile/main.inl
@@ -153,4 +153,12 @@ int main(void) {
     { WGPUVertexState x = WGPU_VERTEX_STATE_INIT; }
     { WGPUFragmentState x = WGPU_FRAGMENT_STATE_INIT; }
     { WGPURenderPipelineDescriptor x = WGPU_RENDER_PIPELINE_DESCRIPTOR_INIT; }
+
+    // Tests for deprecations
+    { WGPUFeatureName x = WGPUDeviceFeatureName_ShaderF16; }
+    { WGPUDeviceFeatureName x = WGPUFeatureName_ShaderF16; }
+    { WGPULimits x = WGPU_DEVICE_LIMITS_INIT; }
+    { WGPUDeviceLimits x = WGPU_LIMITS_INIT; }
+    { WGPUSupportedFeatures x = WGPU_SUPPORTED_DEVICE_FEATURES_INIT; }
+    { WGPUSupportedDeviceFeatures x = WGPU_SUPPORTED_FEATURES_INIT; }
 }

--- a/tests/extensions/webgpu_extension.h
+++ b/tests/extensions/webgpu_extension.h
@@ -33,20 +33,6 @@
  */
 
 /**
- * 'True' value of @ref WGPUBool.
- *
- * @remark It's not usually necessary to use this, as `true` (from
- * `stdbool.h` or C++) casts to the same value.
- */
-#define WGPU_TRUE (UINT32_C(1))
-/**
- * 'False' value of @ref WGPUBool.
- *
- * @remark It's not usually necessary to use this, as `false` (from
- * `stdbool.h` or C++) casts to the same value.
- */
-#define WGPU_FALSE (UINT32_C(0))
-/**
  * New constant should have the namespace prefix in the name by default.
  */
 #define WGPU_PREFIX_NEW_CONSTANT1 (UINT32_MAX)

--- a/webgpu.h
+++ b/webgpu.h
@@ -126,12 +126,12 @@
  */
 #define WGPU_DEPTH_SLICE_UNDEFINED (UINT32_MAX)
 /**
- * For `uint32_t` limits, indicates no limit value is specified. For more info,
+ * For `uint32_t` limits, indicates no limit value is requested. For more info,
  * see @ref SentinelValues and the places that use this sentinel value.
  */
 #define WGPU_LIMIT_U32_UNDEFINED (UINT32_MAX)
 /**
- * For `uint64_t` limits, indicates no limit value is specified. For more info,
+ * For `uint64_t` limits, indicates no limit value is requested. For more info,
  * see @ref SentinelValues and the places that use this sentinel value.
  */
 #define WGPU_LIMIT_U64_UNDEFINED (UINT64_MAX)
@@ -155,6 +155,62 @@
  * see @ref SentinelValues and the places that use this sentinel value.
  */
 #define WGPU_WHOLE_SIZE (UINT64_MAX)
+
+/** @} */
+
+/**
+ * \defgroup Aliases Aliases
+ * \brief Deprecated aliases for other definitions.
+ *
+ * @{
+ */
+
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName WGPUDeviceFeatureName
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_DepthClipControl WGPUDeviceFeatureName_DepthClipControl
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_Depth32FloatStencil8 WGPUDeviceFeatureName_Depth32FloatStencil8
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TimestampQuery WGPUDeviceFeatureName_TimestampQuery
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TextureCompressionBC WGPUDeviceFeatureName_TextureCompressionBC
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TextureCompressionBCSliced3D WGPUDeviceFeatureName_TextureCompressionBCSliced3D
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TextureCompressionETC2 WGPUDeviceFeatureName_TextureCompressionETC2
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TextureCompressionASTC WGPUDeviceFeatureName_TextureCompressionASTC
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_TextureCompressionASTCSliced3D WGPUDeviceFeatureName_TextureCompressionASTCSliced3D
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_IndirectFirstInstance WGPUDeviceFeatureName_IndirectFirstInstance
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_ShaderF16 WGPUDeviceFeatureName_ShaderF16
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_RG11B10UfloatRenderable WGPUDeviceFeatureName_RG11B10UfloatRenderable
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_BGRA8UnormStorage WGPUDeviceFeatureName_BGRA8UnormStorage
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_Float32Filterable WGPUDeviceFeatureName_Float32Filterable
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_Float32Blendable WGPUDeviceFeatureName_Float32Blendable
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_ClipDistances WGPUDeviceFeatureName_ClipDistances
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_DualSourceBlending WGPUDeviceFeatureName_DualSourceBlending
+/** @deprecated alias for the new, more specific enum name. */
+#define WGPUFeatureName_Subgroups WGPUDeviceFeatureName_Subgroups
+
+/** @deprecated alias for the new, more specific struct name. */
+#define WGPULimits WGPUDeviceLimits
+/** @deprecated alias for the new, more specific struct init macro name. */
+#define WGPU_LIMITS_INIT WGPU_DEVICE_LIMITS_INIT
+
+/** @deprecated alias for the new, more specific struct name. */
+#define WGPUSupportedFeatures WGPUSupportedDeviceFeatures
+/** @deprecated alias for the new, more specific struct init macro name. */
+#define WGPU_SUPPORTED_FEATURES_INIT WGPU_SUPPORTED_DEVICE_FEATURES_INIT
 
 /** @} */
 
@@ -260,10 +316,10 @@ struct WGPUCommandBufferDescriptor;
 struct WGPUCommandEncoderDescriptor;
 struct WGPUCompilationMessage;
 struct WGPUConstantEntry;
+struct WGPUDeviceLimits;
 struct WGPUExtent3D;
 struct WGPUFuture;
 struct WGPUInstanceLimits;
-struct WGPULimits;
 struct WGPUMultisampleState;
 struct WGPUOrigin3D;
 struct WGPUPassTimestampWrites;
@@ -284,7 +340,7 @@ struct WGPUShaderSourceSPIRV;
 struct WGPUShaderSourceWGSL;
 struct WGPUStencilFaceState;
 struct WGPUStorageTextureBindingLayout;
-struct WGPUSupportedFeatures;
+struct WGPUSupportedDeviceFeatures;
 struct WGPUSupportedInstanceFeatures;
 struct WGPUSupportedWGSLLanguageFeatures;
 struct WGPUSurfaceCapabilities;
@@ -551,6 +607,27 @@ typedef enum WGPUCullMode {
     WGPUCullMode_Force32 = 0x7FFFFFFF
 } WGPUCullMode WGPU_ENUM_ATTRIBUTE;
 
+typedef enum WGPUDeviceFeatureName {
+    WGPUDeviceFeatureName_DepthClipControl = 0x00000001,
+    WGPUDeviceFeatureName_Depth32FloatStencil8 = 0x00000002,
+    WGPUDeviceFeatureName_TimestampQuery = 0x00000003,
+    WGPUDeviceFeatureName_TextureCompressionBC = 0x00000004,
+    WGPUDeviceFeatureName_TextureCompressionBCSliced3D = 0x00000005,
+    WGPUDeviceFeatureName_TextureCompressionETC2 = 0x00000006,
+    WGPUDeviceFeatureName_TextureCompressionASTC = 0x00000007,
+    WGPUDeviceFeatureName_TextureCompressionASTCSliced3D = 0x00000008,
+    WGPUDeviceFeatureName_IndirectFirstInstance = 0x00000009,
+    WGPUDeviceFeatureName_ShaderF16 = 0x0000000A,
+    WGPUDeviceFeatureName_RG11B10UfloatRenderable = 0x0000000B,
+    WGPUDeviceFeatureName_BGRA8UnormStorage = 0x0000000C,
+    WGPUDeviceFeatureName_Float32Filterable = 0x0000000D,
+    WGPUDeviceFeatureName_Float32Blendable = 0x0000000E,
+    WGPUDeviceFeatureName_ClipDistances = 0x0000000F,
+    WGPUDeviceFeatureName_DualSourceBlending = 0x00000010,
+    WGPUDeviceFeatureName_Subgroups = 0x00000011,
+    WGPUDeviceFeatureName_Force32 = 0x7FFFFFFF
+} WGPUDeviceFeatureName WGPU_ENUM_ATTRIBUTE;
+
 typedef enum WGPUDeviceLostReason {
     WGPUDeviceLostReason_Unknown = 0x00000001,
     WGPUDeviceLostReason_Destroyed = 0x00000002,
@@ -596,27 +673,6 @@ typedef enum WGPUFeatureLevel {
     WGPUFeatureLevel_Core = 0x00000002,
     WGPUFeatureLevel_Force32 = 0x7FFFFFFF
 } WGPUFeatureLevel WGPU_ENUM_ATTRIBUTE;
-
-typedef enum WGPUFeatureName {
-    WGPUFeatureName_DepthClipControl = 0x00000001,
-    WGPUFeatureName_Depth32FloatStencil8 = 0x00000002,
-    WGPUFeatureName_TimestampQuery = 0x00000003,
-    WGPUFeatureName_TextureCompressionBC = 0x00000004,
-    WGPUFeatureName_TextureCompressionBCSliced3D = 0x00000005,
-    WGPUFeatureName_TextureCompressionETC2 = 0x00000006,
-    WGPUFeatureName_TextureCompressionASTC = 0x00000007,
-    WGPUFeatureName_TextureCompressionASTCSliced3D = 0x00000008,
-    WGPUFeatureName_IndirectFirstInstance = 0x00000009,
-    WGPUFeatureName_ShaderF16 = 0x0000000A,
-    WGPUFeatureName_RG11B10UfloatRenderable = 0x0000000B,
-    WGPUFeatureName_BGRA8UnormStorage = 0x0000000C,
-    WGPUFeatureName_Float32Filterable = 0x0000000D,
-    WGPUFeatureName_Float32Blendable = 0x0000000E,
-    WGPUFeatureName_ClipDistances = 0x0000000F,
-    WGPUFeatureName_DualSourceBlending = 0x00000010,
-    WGPUFeatureName_Subgroups = 0x00000011,
-    WGPUFeatureName_Force32 = 0x7FFFFFFF
-} WGPUFeatureName WGPU_ENUM_ATTRIBUTE;
 
 typedef enum WGPUFilterMode {
     /**
@@ -2101,78 +2157,13 @@ typedef struct WGPUConstantEntry {
 })
 
 /**
- * Default values can be set using @ref WGPU_EXTENT_3D_INIT as initializer.
- */
-typedef struct WGPUExtent3D {
-    /**
-     * The `INIT` macro sets this to `0`.
-     */
-    uint32_t width;
-    /**
-     * The `INIT` macro sets this to `1`.
-     */
-    uint32_t height;
-    /**
-     * The `INIT` macro sets this to `1`.
-     */
-    uint32_t depthOrArrayLayers;
-} WGPUExtent3D WGPU_STRUCTURE_ATTRIBUTE;
-
-/**
- * Initializer for @ref WGPUExtent3D.
- */
-#define WGPU_EXTENT_3D_INIT _wgpu_MAKE_INIT_STRUCT(WGPUExtent3D, { \
-    /*.width=*/0 _wgpu_COMMA \
-    /*.height=*/1 _wgpu_COMMA \
-    /*.depthOrArrayLayers=*/1 _wgpu_COMMA \
-})
-
-/**
- * Opaque handle to an asynchronous operation. See @ref Asynchronous-Operations for more information.
+ * Limits of a @ref WGPUAdapter, @ref WGPUDeviceDescriptor, or @ref WGPUDevice.
+ * In @ref WGPUDeviceDescriptor, an `UNDEFINED` sentinel value
+ * indicates no request for that limit.
  *
- * Default values can be set using @ref WGPU_FUTURE_INIT as initializer.
+ * Default values can be set using @ref WGPU_DEVICE_LIMITS_INIT as initializer.
  */
-typedef struct WGPUFuture {
-    /**
-     * Opaque id of the @ref WGPUFuture
-     *
-     * The `INIT` macro sets this to `0`.
-     */
-    uint64_t id;
-} WGPUFuture WGPU_STRUCTURE_ATTRIBUTE;
-
-/**
- * Initializer for @ref WGPUFuture.
- */
-#define WGPU_FUTURE_INIT _wgpu_MAKE_INIT_STRUCT(WGPUFuture, { \
-    /*.id=*/0 _wgpu_COMMA \
-})
-
-/**
- * Default values can be set using @ref WGPU_INSTANCE_LIMITS_INIT as initializer.
- */
-typedef struct WGPUInstanceLimits {
-    WGPUChainedStruct * nextInChain;
-    /**
-     * The maximum number @ref WGPUFutureWaitInfo supported in a call to ::wgpuInstanceWaitAny with `timeoutNS > 0`.
-     *
-     * The `INIT` macro sets this to `0`.
-     */
-    size_t timedWaitAnyMaxCount;
-} WGPUInstanceLimits WGPU_STRUCTURE_ATTRIBUTE;
-
-/**
- * Initializer for @ref WGPUInstanceLimits.
- */
-#define WGPU_INSTANCE_LIMITS_INIT _wgpu_MAKE_INIT_STRUCT(WGPUInstanceLimits, { \
-    /*.nextInChain=*/NULL _wgpu_COMMA \
-    /*.timedWaitAnyMaxCount=*/0 _wgpu_COMMA \
-})
-
-/**
- * Default values can be set using @ref WGPU_LIMITS_INIT as initializer.
- */
-typedef struct WGPULimits {
+typedef struct WGPUDeviceLimits {
     WGPUChainedStruct * nextInChain;
     /**
      * The `INIT` macro sets this to @ref WGPU_LIMIT_U32_UNDEFINED.
@@ -2302,12 +2293,12 @@ typedef struct WGPULimits {
      * The `INIT` macro sets this to `0`.
      */
     uint32_t maxImmediateSize;
-} WGPULimits WGPU_STRUCTURE_ATTRIBUTE;
+} WGPUDeviceLimits WGPU_STRUCTURE_ATTRIBUTE;
 
 /**
- * Initializer for @ref WGPULimits.
+ * Initializer for @ref WGPUDeviceLimits.
  */
-#define WGPU_LIMITS_INIT _wgpu_MAKE_INIT_STRUCT(WGPULimits, { \
+#define WGPU_DEVICE_LIMITS_INIT _wgpu_MAKE_INIT_STRUCT(WGPUDeviceLimits, { \
     /*.nextInChain=*/NULL _wgpu_COMMA \
     /*.maxTextureDimension1D=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxTextureDimension2D=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
@@ -2341,6 +2332,77 @@ typedef struct WGPULimits {
     /*.maxComputeWorkgroupSizeZ=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxComputeWorkgroupsPerDimension=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxImmediateSize=*/0 _wgpu_COMMA \
+})
+
+/**
+ * Default values can be set using @ref WGPU_EXTENT_3D_INIT as initializer.
+ */
+typedef struct WGPUExtent3D {
+    /**
+     * The `INIT` macro sets this to `0`.
+     */
+    uint32_t width;
+    /**
+     * The `INIT` macro sets this to `1`.
+     */
+    uint32_t height;
+    /**
+     * The `INIT` macro sets this to `1`.
+     */
+    uint32_t depthOrArrayLayers;
+} WGPUExtent3D WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Initializer for @ref WGPUExtent3D.
+ */
+#define WGPU_EXTENT_3D_INIT _wgpu_MAKE_INIT_STRUCT(WGPUExtent3D, { \
+    /*.width=*/0 _wgpu_COMMA \
+    /*.height=*/1 _wgpu_COMMA \
+    /*.depthOrArrayLayers=*/1 _wgpu_COMMA \
+})
+
+/**
+ * Opaque handle to an asynchronous operation. See @ref Asynchronous-Operations for more information.
+ *
+ * Default values can be set using @ref WGPU_FUTURE_INIT as initializer.
+ */
+typedef struct WGPUFuture {
+    /**
+     * Opaque id of the @ref WGPUFuture
+     *
+     * The `INIT` macro sets this to `0`.
+     */
+    uint64_t id;
+} WGPUFuture WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Initializer for @ref WGPUFuture.
+ */
+#define WGPU_FUTURE_INIT _wgpu_MAKE_INIT_STRUCT(WGPUFuture, { \
+    /*.id=*/0 _wgpu_COMMA \
+})
+
+/**
+ * Limits of a @ref WGPUInstanceDescriptor or @ref WGPUInstance.
+ *
+ * Default values can be set using @ref WGPU_INSTANCE_LIMITS_INIT as initializer.
+ */
+typedef struct WGPUInstanceLimits {
+    WGPUChainedStruct * nextInChain;
+    /**
+     * The maximum number @ref WGPUFutureWaitInfo supported in a call to ::wgpuInstanceWaitAny with `timeoutNS > 0`.
+     *
+     * The `INIT` macro sets this to `0`.
+     */
+    size_t timedWaitAnyMaxCount;
+} WGPUInstanceLimits WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Initializer for @ref WGPUInstanceLimits.
+ */
+#define WGPU_INSTANCE_LIMITS_INIT _wgpu_MAKE_INIT_STRUCT(WGPUInstanceLimits, { \
+    /*.nextInChain=*/NULL _wgpu_COMMA \
+    /*.timedWaitAnyMaxCount=*/0 _wgpu_COMMA \
 })
 
 /**
@@ -3078,9 +3140,9 @@ typedef struct WGPUStorageTextureBindingLayout {
 })
 
 /**
- * Default values can be set using @ref WGPU_SUPPORTED_FEATURES_INIT as initializer.
+ * Default values can be set using @ref WGPU_SUPPORTED_DEVICE_FEATURES_INIT as initializer.
  */
-typedef struct WGPUSupportedFeatures {
+typedef struct WGPUSupportedDeviceFeatures {
     /**
      * Array count for `features`. The `INIT` macro sets this to 0.
      */
@@ -3088,13 +3150,13 @@ typedef struct WGPUSupportedFeatures {
     /**
      * The `INIT` macro sets this to `NULL`.
      */
-    WGPUFeatureName const * features;
-} WGPUSupportedFeatures WGPU_STRUCTURE_ATTRIBUTE;
+    WGPUDeviceFeatureName const * features;
+} WGPUSupportedDeviceFeatures WGPU_STRUCTURE_ATTRIBUTE;
 
 /**
- * Initializer for @ref WGPUSupportedFeatures.
+ * Initializer for @ref WGPUSupportedDeviceFeatures.
  */
-#define WGPU_SUPPORTED_FEATURES_INIT _wgpu_MAKE_INIT_STRUCT(WGPUSupportedFeatures, { \
+#define WGPU_SUPPORTED_DEVICE_FEATURES_INIT _wgpu_MAKE_INIT_STRUCT(WGPUSupportedDeviceFeatures, { \
     /*.featureCount=*/0 _wgpu_COMMA \
     /*.features=*/NULL _wgpu_COMMA \
 })
@@ -4006,11 +4068,11 @@ typedef struct WGPUDeviceDescriptor {
     /**
      * The `INIT` macro sets this to `NULL`.
      */
-    WGPUFeatureName const * requiredFeatures;
+    WGPUDeviceFeatureName const * requiredFeatures;
     /**
      * The `INIT` macro sets this to `NULL`.
      */
-    WGPU_NULLABLE WGPULimits const * requiredLimits;
+    WGPU_NULLABLE WGPUDeviceLimits const * requiredLimits;
     /**
      * The `INIT` macro sets this to @ref WGPU_QUEUE_DESCRIPTOR_INIT.
      */
@@ -4640,7 +4702,7 @@ typedef WGPUProc (*WGPUProcGetProcAddress)(WGPUStringView procName) WGPU_FUNCTIO
  * Proc pointer type for @ref wgpuAdapterGetFeatures:
  * > @copydoc wgpuAdapterGetFeatures
  */
-typedef void (*WGPUProcAdapterGetFeatures)(WGPUAdapter adapter, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcAdapterGetFeatures)(WGPUAdapter adapter, WGPUSupportedDeviceFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuAdapterGetInfo:
  * > @copydoc wgpuAdapterGetInfo
@@ -4650,12 +4712,12 @@ typedef WGPUStatus (*WGPUProcAdapterGetInfo)(WGPUAdapter adapter, WGPUAdapterInf
  * Proc pointer type for @ref wgpuAdapterGetLimits:
  * > @copydoc wgpuAdapterGetLimits
  */
-typedef WGPUStatus (*WGPUProcAdapterGetLimits)(WGPUAdapter adapter, WGPULimits * limits) WGPU_FUNCTION_ATTRIBUTE;
+typedef WGPUStatus (*WGPUProcAdapterGetLimits)(WGPUAdapter adapter, WGPUDeviceLimits * limits) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuAdapterHasFeature:
  * > @copydoc wgpuAdapterHasFeature
  */
-typedef WGPUBool (*WGPUProcAdapterHasFeature)(WGPUAdapter adapter, WGPUFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
+typedef WGPUBool (*WGPUProcAdapterHasFeature)(WGPUAdapter adapter, WGPUDeviceFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuAdapterRequestDevice:
  * > @copydoc wgpuAdapterRequestDevice
@@ -5043,12 +5105,12 @@ typedef WGPUStatus (*WGPUProcDeviceGetAdapterInfo)(WGPUDevice device, WGPUAdapte
  * Proc pointer type for @ref wgpuDeviceGetFeatures:
  * > @copydoc wgpuDeviceGetFeatures
  */
-typedef void (*WGPUProcDeviceGetFeatures)(WGPUDevice device, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcDeviceGetFeatures)(WGPUDevice device, WGPUSupportedDeviceFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuDeviceGetLimits:
  * > @copydoc wgpuDeviceGetLimits
  */
-typedef WGPUStatus (*WGPUProcDeviceGetLimits)(WGPUDevice device, WGPULimits * limits) WGPU_FUNCTION_ATTRIBUTE;
+typedef WGPUStatus (*WGPUProcDeviceGetLimits)(WGPUDevice device, WGPUDeviceLimits * limits) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuDeviceGetLostFuture:
  * > @copydoc wgpuDeviceGetLostFuture
@@ -5063,7 +5125,7 @@ typedef WGPUQueue (*WGPUProcDeviceGetQueue)(WGPUDevice device) WGPU_FUNCTION_ATT
  * Proc pointer type for @ref wgpuDeviceHasFeature:
  * > @copydoc wgpuDeviceHasFeature
  */
-typedef WGPUBool (*WGPUProcDeviceHasFeature)(WGPUDevice device, WGPUFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
+typedef WGPUBool (*WGPUProcDeviceHasFeature)(WGPUDevice device, WGPUDeviceFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuDevicePopErrorScope:
  * > @copydoc wgpuDevicePopErrorScope
@@ -5485,12 +5547,12 @@ typedef void (*WGPUProcShaderModuleAddRef)(WGPUShaderModule shaderModule) WGPU_F
  */
 typedef void (*WGPUProcShaderModuleRelease)(WGPUShaderModule shaderModule) WGPU_FUNCTION_ATTRIBUTE;
 
-// Procs of SupportedFeatures
+// Procs of SupportedDeviceFeatures
 /**
- * Proc pointer type for @ref wgpuSupportedFeaturesFreeMembers:
- * > @copydoc wgpuSupportedFeaturesFreeMembers
+ * Proc pointer type for @ref wgpuSupportedDeviceFeaturesFreeMembers:
+ * > @copydoc wgpuSupportedDeviceFeaturesFreeMembers
  */
-typedef void (*WGPUProcSupportedFeaturesFreeMembers)(WGPUSupportedFeatures supportedFeatures) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcSupportedDeviceFeaturesFreeMembers)(WGPUSupportedDeviceFeatures supportedDeviceFeatures) WGPU_FUNCTION_ATTRIBUTE;
 
 // Procs of SupportedInstanceFeatures
 /**
@@ -5701,7 +5763,7 @@ WGPU_EXPORT WGPUProc wgpuGetProcAddress(WGPUStringView procName) WGPU_FUNCTION_A
  * @param features
  * This parameter is @ref ReturnedWithOwnership.
  */
-WGPU_EXPORT void wgpuAdapterGetFeatures(WGPUAdapter adapter, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuAdapterGetFeatures(WGPUAdapter adapter, WGPUSupportedDeviceFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * @param info
  * This parameter is @ref ReturnedWithOwnership.
@@ -5714,8 +5776,8 @@ WGPU_EXPORT WGPUStatus wgpuAdapterGetInfo(WGPUAdapter adapter, WGPUAdapterInfo *
  * @returns
  * Indicates if there was an @ref OutStructChainError.
  */
-WGPU_EXPORT WGPUStatus wgpuAdapterGetLimits(WGPUAdapter adapter, WGPULimits * limits) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT WGPUBool wgpuAdapterHasFeature(WGPUAdapter adapter, WGPUFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT WGPUStatus wgpuAdapterGetLimits(WGPUAdapter adapter, WGPUDeviceLimits * limits) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT WGPUBool wgpuAdapterHasFeature(WGPUAdapter adapter, WGPUDeviceFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUFuture wgpuAdapterRequestDevice(WGPUAdapter adapter, WGPU_NULLABLE WGPUDeviceDescriptor const * descriptor, WGPURequestDeviceCallbackInfo callbackInfo) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuAdapterAddRef(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuAdapterRelease(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;
@@ -6027,12 +6089,12 @@ WGPU_EXPORT WGPUStatus wgpuDeviceGetAdapterInfo(WGPUDevice device, WGPUAdapterIn
  * @param features
  * This parameter is @ref ReturnedWithOwnership.
  */
-WGPU_EXPORT void wgpuDeviceGetFeatures(WGPUDevice device, WGPUSupportedFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuDeviceGetFeatures(WGPUDevice device, WGPUSupportedDeviceFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * @returns
  * Indicates if there was an @ref OutStructChainError.
  */
-WGPU_EXPORT WGPUStatus wgpuDeviceGetLimits(WGPUDevice device, WGPULimits * limits) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT WGPUStatus wgpuDeviceGetLimits(WGPUDevice device, WGPUDeviceLimits * limits) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * @returns
  * The @ref WGPUFuture for the device-lost event of the device.
@@ -6043,7 +6105,7 @@ WGPU_EXPORT WGPUFuture wgpuDeviceGetLostFuture(WGPUDevice device) WGPU_FUNCTION_
  * This value is @ref ReturnedWithOwnership.
  */
 WGPU_EXPORT WGPUQueue wgpuDeviceGetQueue(WGPUDevice device) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT WGPUBool wgpuDeviceHasFeature(WGPUDevice device, WGPUFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT WGPUBool wgpuDeviceHasFeature(WGPUDevice device, WGPUDeviceFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Pops an error scope to the current thread's error scope stack,
  * asynchronously returning the result. See @ref ErrorScopes.
@@ -6259,15 +6321,15 @@ WGPU_EXPORT void wgpuShaderModuleRelease(WGPUShaderModule shaderModule) WGPU_FUN
 /** @} */
 
 /**
- * \defgroup WGPUSupportedFeaturesMethods WGPUSupportedFeatures methods
- * \brief Functions whose first argument has type WGPUSupportedFeatures.
+ * \defgroup WGPUSupportedDeviceFeaturesMethods WGPUSupportedDeviceFeatures methods
+ * \brief Functions whose first argument has type WGPUSupportedDeviceFeatures.
  *
  * @{
  */
 /**
  * Frees members which were allocated by the API.
  */
-WGPU_EXPORT void wgpuSupportedFeaturesFreeMembers(WGPUSupportedFeatures supportedFeatures) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuSupportedDeviceFeaturesFreeMembers(WGPUSupportedDeviceFeatures supportedDeviceFeatures) WGPU_FUNCTION_ATTRIBUTE;
 /** @} */
 
 /**

--- a/webgpu.h
+++ b/webgpu.h
@@ -45,6 +45,10 @@
 #    define WGPU_EXPORT
 #endif  // defined(WGPU_SHARED_LIBRARY)
 
+#if !defined(WGPU_DISABLE_DEPRECATED_ALIASES)
+#define WGPU_DISABLE_DEPRECATED_ALIASES 0
+#endif
+
 #if !defined(WGPU_OBJECT_ATTRIBUTE)
 #define WGPU_OBJECT_ATTRIBUTE
 #endif
@@ -164,6 +168,7 @@
  *
  * @{
  */
+#if !WGPU_DISABLE_DEPRECATED_ALIASES
 
 /** @deprecated alias for the new, more specific enum name. */
 #define WGPUFeatureName WGPUDeviceFeatureName
@@ -212,6 +217,7 @@
 /** @deprecated alias for the new, more specific struct init macro name. */
 #define WGPU_SUPPORTED_FEATURES_INIT WGPU_SUPPORTED_DEVICE_FEATURES_INIT
 
+#endif // !WGPU_DISABLE_DEPRECATED_ALIASES
 /** @} */
 
 /**

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -42,12 +42,12 @@ constants:
   - name: limit_u32_undefined
     value: uint32_max
     doc: |
-      For `uint32_t` limits, indicates no limit value is specified. For more info,
+      For `uint32_t` limits, indicates no limit value is requested. For more info,
       see @ref SentinelValues and the places that use this sentinel value.
   - name: limit_u64_undefined
     value: uint64_max
     doc: |
-      For `uint64_t` limits, indicates no limit value is specified. For more info,
+      For `uint64_t` limits, indicates no limit value is requested. For more info,
       see @ref SentinelValues and the places that use this sentinel value.
   - name: mip_level_count_undefined
     value: uint32_max
@@ -369,6 +369,62 @@ enums:
       - name: back
         doc: |
           TODO
+  - name: device_feature_name
+    doc: |
+      TODO
+    entries:
+      - null
+      - name: depth_clip_control
+        doc: |
+          TODO
+      - name: depth32_float_stencil8
+        doc: |
+          TODO
+      - name: timestamp_query
+        doc: |
+          TODO
+      - name: texture_compression_BC
+        doc: |
+          TODO
+      - name: texture_compression_BC_sliced_3D
+        doc: |
+          TODO
+      - name: texture_compression_ETC2
+        doc: |
+          TODO
+      - name: texture_compression_ASTC
+        doc: |
+          TODO
+      - name: texture_compression_ASTC_sliced_3D
+        doc: |
+          TODO
+      - name: indirect_first_instance
+        doc: |
+          TODO
+      - name: shader_f16
+        doc: |
+          TODO
+      - name: RG11B10_ufloat_renderable
+        doc: |
+          TODO
+      - name: BGRA8_unorm_storage
+        doc: |
+          TODO
+      - name: float32_filterable
+        doc: |
+          TODO
+      - name: float32_blendable
+        doc: |
+          TODO
+      - name: clip_distances
+        doc: |
+          TODO
+      - name: dual_source_blending
+        doc: |
+          TODO
+      - name: subgroups
+        doc: |
+          TODO
   - name: device_lost_reason
     doc: |
       TODO
@@ -432,62 +488,6 @@ enums:
       - name: core
         doc: |
           "Core" profile which can be supported on Vulkan/Metal/D3D12 (at least).
-  - name: feature_name
-    doc: |
-      TODO
-    entries:
-      - null
-      - name: depth_clip_control
-        doc: |
-          TODO
-      - name: depth32_float_stencil8
-        doc: |
-          TODO
-      - name: timestamp_query
-        doc: |
-          TODO
-      - name: texture_compression_BC
-        doc: |
-          TODO
-      - name: texture_compression_BC_sliced_3D
-        doc: |
-          TODO
-      - name: texture_compression_ETC2
-        doc: |
-          TODO
-      - name: texture_compression_ASTC
-        doc: |
-          TODO
-      - name: texture_compression_ASTC_sliced_3D
-        doc: |
-          TODO
-      - name: indirect_first_instance
-        doc: |
-          TODO
-      - name: shader_f16
-        doc: |
-          TODO
-      - name: RG11B10_ufloat_renderable
-        doc: |
-          TODO
-      - name: BGRA8_unorm_storage
-        doc: |
-          TODO
-      - name: float32_filterable
-        doc: |
-          TODO
-      - name: float32_blendable
-        doc: |
-          TODO
-      - name: clip_distances
-        doc: |
-          TODO
-      - name: dual_source_blending
-        doc: |
-          TODO
-      - name: subgroups
-        doc: |
-          TODO
   - name: filter_mode
     doc: |
       TODO
@@ -2031,12 +2031,12 @@ structs:
       - name: required_features
         doc: |
           TODO
-        type: array<enum.feature_name>
+        type: array<enum.device_feature_name>
         pointer: immutable
       - name: required_limits
         doc: |
           TODO
-        type: struct.limits
+        type: struct.device_limits
         pointer: immutable
         optional: true
       - name: default_queue
@@ -2054,92 +2054,11 @@ structs:
 
           **Important:** This callback does not have a configurable @ref WGPUCallbackMode; it may be called at any time (like @ref WGPUCallbackMode_AllowSpontaneous). As such, calls into the `webgpu.h` API from this callback are unsafe. See @ref CallbackReentrancy.
         type: callback.uncaptured_error
-  - name: extent_3D
+  - name: device_limits
     doc: |
-      TODO
-    type: standalone
-    members:
-      - name: width
-        doc: |
-          TODO
-        type: uint32
-      - name: height
-        doc: |
-          TODO
-        type: uint32
-        default: 1
-      - name: depth_or_array_layers
-        doc: |
-          TODO
-        type: uint32
-        default: 1
-  - name: fragment_state
-    doc: |
-      TODO
-    type: extensible
-    members:
-      - name: module
-        doc: |
-          TODO
-        type: object.shader_module
-      - name: entry_point
-        doc: |
-          TODO
-        type: nullable_string
-      - name: constants
-        doc: |
-          TODO
-        type: array<struct.constant_entry>
-        pointer: immutable
-      - name: targets
-        doc: |
-          TODO
-        type: array<struct.color_target_state>
-        pointer: immutable
-  - name: future
-    doc: Opaque handle to an asynchronous operation. See @ref Asynchronous-Operations for more information.
-    type: standalone
-    members:
-      - name: id
-        doc: Opaque id of the @ref WGPUFuture
-        type: uint64
-  - name: future_wait_info
-    doc: Struct holding a future to wait on, and a `completed` boolean flag.
-    type: standalone
-    members:
-      - name: future
-        doc: The future to wait on.
-        type: struct.future
-      - name: completed
-        doc: Whether or not the future completed.
-        type: bool
-  - name: instance_descriptor
-    doc: |
-      TODO
-    type: extensible
-    members:
-      - name: required_features
-        doc: |
-          TODO
-        type: array<enum.instance_feature_name>
-        pointer: immutable
-      - name: required_limits
-        doc: |
-          TODO
-        type: struct.instance_limits
-        pointer: immutable
-        optional: true
-  - name: instance_limits
-    doc: |
-      TODO
-    type: extensible
-    members:
-      - name: timed_wait_any_max_count
-        doc: The maximum number @ref WGPUFutureWaitInfo supported in a call to ::wgpuInstanceWaitAny with `timeoutNS > 0`.
-        type: usize
-  - name: limits
-    doc: |
-      TODO
+      Limits of a @ref WGPUAdapter, @ref WGPUDeviceDescriptor, or @ref WGPUDevice.
+      In @ref WGPUDeviceDescriptor, an `UNDEFINED` sentinel value
+      indicates no request for that limit.
     type: extensible
     members:
       - name: max_texture_dimension_1D
@@ -2301,6 +2220,89 @@ structs:
         doc: |
           TODO
         type: uint32
+  - name: extent_3D
+    doc: |
+      TODO
+    type: standalone
+    members:
+      - name: width
+        doc: |
+          TODO
+        type: uint32
+      - name: height
+        doc: |
+          TODO
+        type: uint32
+        default: 1
+      - name: depth_or_array_layers
+        doc: |
+          TODO
+        type: uint32
+        default: 1
+  - name: fragment_state
+    doc: |
+      TODO
+    type: extensible
+    members:
+      - name: module
+        doc: |
+          TODO
+        type: object.shader_module
+      - name: entry_point
+        doc: |
+          TODO
+        type: nullable_string
+      - name: constants
+        doc: |
+          TODO
+        type: array<struct.constant_entry>
+        pointer: immutable
+      - name: targets
+        doc: |
+          TODO
+        type: array<struct.color_target_state>
+        pointer: immutable
+  - name: future
+    doc: Opaque handle to an asynchronous operation. See @ref Asynchronous-Operations for more information.
+    type: standalone
+    members:
+      - name: id
+        doc: Opaque id of the @ref WGPUFuture
+        type: uint64
+  - name: future_wait_info
+    doc: Struct holding a future to wait on, and a `completed` boolean flag.
+    type: standalone
+    members:
+      - name: future
+        doc: The future to wait on.
+        type: struct.future
+      - name: completed
+        doc: Whether or not the future completed.
+        type: bool
+  - name: instance_descriptor
+    doc: |
+      TODO
+    type: extensible
+    members:
+      - name: required_features
+        doc: |
+          TODO
+        type: array<enum.instance_feature_name>
+        pointer: immutable
+      - name: required_limits
+        doc: |
+          TODO
+        type: struct.instance_limits
+        pointer: immutable
+        optional: true
+  - name: instance_limits
+    doc: |
+      Limits of a @ref WGPUInstanceDescriptor or @ref WGPUInstance.
+    type: extensible
+    members:
+      - name: timed_wait_any_max_count
+        doc: The maximum number @ref WGPUFutureWaitInfo supported in a call to ::wgpuInstanceWaitAny with `timeoutNS > 0`.
+        type: usize
   - name: multisample_state
     doc: |
       TODO
@@ -2865,7 +2867,7 @@ structs:
           [defaults](@ref SentinelValues) to @ref WGPUTextureViewDimension_2D.
         type: enum.texture_view_dimension
         default: undefined
-  - name: supported_features
+  - name: supported_device_features
     doc: |
       TODO
     type: standalone
@@ -2874,7 +2876,7 @@ structs:
       - name: features
         doc: |
           TODO
-        type: array<enum.feature_name>
+        type: array<enum.device_feature_name>
         pointer: immutable
   - name: supported_instance_features
     doc: |
@@ -3571,7 +3573,7 @@ objects:
           - name: limits
             doc: |
               TODO
-            type: struct.limits
+            type: struct.device_limits
             pointer: mutable
       - name: has_feature
         doc: |
@@ -3584,7 +3586,7 @@ objects:
           - name: feature
             doc: |
               TODO
-            type: enum.feature_name
+            type: enum.device_feature_name
       - name: get_features
         doc: |
           Get the list of @ref WGPUFeatureName values supported by the adapter.
@@ -3592,7 +3594,7 @@ objects:
           - name: features
             doc: |
               TODO
-            type: struct.supported_features
+            type: struct.supported_device_features
             pointer: mutable
             passed_with_ownership: true
       - name: get_info
@@ -4352,7 +4354,7 @@ objects:
           - name: limits
             doc: |
               TODO
-            type: struct.limits
+            type: struct.device_limits
             pointer: mutable
       - name: has_feature
         doc: |
@@ -4365,7 +4367,7 @@ objects:
           - name: feature
             doc: |
               TODO
-            type: enum.feature_name
+            type: enum.device_feature_name
       - name: get_features
         doc: |
           Get the list of @ref WGPUFeatureName values supported by the device.
@@ -4373,7 +4375,7 @@ objects:
           - name: features
             doc: |
               TODO
-            type: struct.supported_features
+            type: struct.supported_device_features
             pointer: mutable
             passed_with_ownership: true
       - name: get_adapter_info


### PR DESCRIPTION
As was proposed in the meeting. I'm still not really convinced this is worthwhile, but it is a little clearer (especially in C where you don't get much type safety - you can freely assign a `WGPUFeatureName` value to a `WGPUInstanceFeatureName` variable).

~We could also consider just removing the old names. The migration is probably not so hard that this is necessarily worth keeping around.~ I did add a macro to disable the aliases though.

Also removes WGPU_TRUE/WGPU_FALSE from extension headers. Accidentally added those, they aren't needed since extensions include `webgpu.h`.

Fixes #522