### PR TITLE
Fix INIT macro for maxImmediateSize

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -2306,7 +2306,7 @@ typedef struct WGPULimits {
      */
     uint32_t maxComputeWorkgroupsPerDimension;
     /**
-     * The `INIT` macro sets this to `0`.
+     * The `INIT` macro sets this to @ref WGPU_LIMIT_U32_UNDEFINED.
      */
     uint32_t maxImmediateSize;
 } WGPULimits WGPU_STRUCTURE_ATTRIBUTE;
@@ -2347,7 +2347,7 @@ typedef struct WGPULimits {
     /*.maxComputeWorkgroupSizeY=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxComputeWorkgroupSizeZ=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxComputeWorkgroupsPerDimension=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
-    /*.maxImmediateSize=*/0 _wgpu_COMMA \
+    /*.maxImmediateSize=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
 })
 
 /**

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -2312,6 +2312,7 @@ structs:
         doc: |
           TODO
         type: uint32
+        default: constant.limit_u32_undefined
   - name: multisample_state
     doc: |
       TODO


### PR DESCRIPTION
This should be WGPU_LIMIT_U32_UNDEFINED like other limits, not 0. I assume this was just a typo on my part in the original PR #529.

Found because there was an [unexpected diff](https://source.chromium.org/chromium/chromium/src/+/main:third_party/dawn/third_party/webgpu-headers/webgpu.h.diff;l=234-235;drc=892bb94dfc85a3e60b25eb2c6e707adfd58e1079) between Dawn's webgpu.h and this one.