### PR TITLE
[breaking] Remove return value from wgpuInstanceGetWGSLLanguageFeatures

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -5116,7 +5116,7 @@ typedef WGPUSurface (*WGPUProcInstanceCreateSurface)(WGPUInstance instance, WGPU
  * Proc pointer type for @ref wgpuInstanceGetWGSLLanguageFeatures:
  * > @copydoc wgpuInstanceGetWGSLLanguageFeatures
  */
-typedef WGPUStatus (*WGPUProcInstanceGetWGSLLanguageFeatures)(WGPUInstance instance, WGPUSupportedWGSLLanguageFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcInstanceGetWGSLLanguageFeatures)(WGPUInstance instance, WGPUSupportedWGSLLanguageFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuInstanceHasWGSLLanguageFeature:
  * > @copydoc wgpuInstanceHasWGSLLanguageFeature
@@ -6104,7 +6104,7 @@ WGPU_EXPORT WGPUSurface wgpuInstanceCreateSurface(WGPUInstance instance, WGPUSur
 /**
  * Get the list of @ref WGPUWGSLLanguageFeatureName values supported by the instance.
  */
-WGPU_EXPORT WGPUStatus wgpuInstanceGetWGSLLanguageFeatures(WGPUInstance instance, WGPUSupportedWGSLLanguageFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuInstanceGetWGSLLanguageFeatures(WGPUInstance instance, WGPUSupportedWGSLLanguageFeatures * features) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBool wgpuInstanceHasWGSLLanguageFeature(WGPUInstance instance, WGPUWGSLLanguageFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Processes asynchronous events on this `WGPUInstance`, calling any callbacks for asynchronous operations created with @ref WGPUCallbackMode_AllowProcessEvents.

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -4432,10 +4432,6 @@ objects:
       - name: get_WGSL_language_features
         doc: |
           Get the list of @ref WGPUWGSLLanguageFeatureName values supported by the instance.
-        returns:
-          doc: |
-            TODO
-          type: enum.status
         args:
           - name: features
             doc: |


### PR DESCRIPTION
This method has no error conditions, so it should return void like wgpuAdapter/DeviceGetFeatures and wgpuGetInstanceFeatures.