### PR TITLE
Add primitive-index GPUFeatureName

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -617,6 +617,7 @@ typedef enum WGPUFeatureName {
     WGPUFeatureName_Subgroups = 0x00000012,
     WGPUFeatureName_TextureFormatsTier1 = 0x00000013,
     WGPUFeatureName_TextureFormatsTier2 = 0x00000014,
+    WGPUFeatureName_PrimitiveIndex = 0x00000015,
     WGPUFeatureName_Force32 = 0x7FFFFFFF
 } WGPUFeatureName WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -502,6 +502,9 @@ enums:
       - name: texture_formats_tier_2
         doc: |
           TODO
+      - name: primitive_index
+        doc: |
+          TODO
   - name: filter_mode
     doc: |
       TODO


### PR DESCRIPTION
Following up on https://github.com/gpuweb/gpuweb/pull/5273, this PR adds the `"primitive-index"` GPUFeatureName.