### PR TITLE
Mark webgpu.h header stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # WebGPU Headers
 
-This repository contains C headers equivalent to the [WebGPU](https://gpuweb.github.io/gpuweb/) API and documentation on the native specificities of the headers.
+This repository contains C stable headers equivalent to the [WebGPU](https://gpuweb.github.io/gpuweb/) API and documentation on the native specificities of the headers.
 
-**This header is NOT STABLE yet, and the documentation is very much a work in progress!**
+**The documentation is very much a work in progress!**
 
 All of the API is defined in the [webgpu.h](./webgpu.h) header file.
 **[Read the documentation here!](https://webgpu-native.github.io/webgpu-headers/)**


### PR DESCRIPTION
I believe we can now remove `This header is NOT STABLE yet`  from the README.md file since https://www.khronos.org/assets/uploads/developers/presentations/WebGL%2BWebGPU_SIGGRAPH_2025.pdf#page=19

If so, I'll also update our documentation:
- [ ] https://developer.chrome.com/docs/web-platform/webgpu/build-app?hl=en#how_does_it_work
- [ ] https://developer.chrome.com/docs/web-platform/webgpu/build-app?hl=en#whats_next
- [ ] https://github.com/beaufortfrancois/webgpu-cross-platform-app?tab=readme-ov-file#webgpu-cross-platform-app-with-cmakeemscripten