### PR TITLE
Add wgpuTextureGetTextureBindingViewDimension

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -5803,6 +5803,11 @@ typedef uint32_t (*WGPUProcTextureGetMipLevelCount)(WGPUTexture texture) WGPU_FU
  */
 typedef uint32_t (*WGPUProcTextureGetSampleCount)(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 /**
+ * Proc pointer type for @ref wgpuTextureGetTextureBindingViewDimension:
+ * > @copydoc wgpuTextureGetTextureBindingViewDimension
+ */
+typedef WGPUTextureViewDimension (*WGPUProcTextureGetTextureBindingViewDimension)(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
+/**
  * Proc pointer type for @ref wgpuTextureGetUsage:
  * > @copydoc wgpuTextureGetUsage
  */
@@ -6635,6 +6640,7 @@ WGPU_EXPORT WGPUTextureFormat wgpuTextureGetFormat(WGPUTexture texture) WGPU_FUN
 WGPU_EXPORT uint32_t wgpuTextureGetHeight(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT uint32_t wgpuTextureGetMipLevelCount(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT uint32_t wgpuTextureGetSampleCount(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT WGPUTextureViewDimension wgpuTextureGetTextureBindingViewDimension(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUTextureUsage wgpuTextureGetUsage(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT uint32_t wgpuTextureGetWidth(WGPUTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuTextureSetLabel(WGPUTexture texture, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;

--- a/webgpu.json
+++ b/webgpu.json
@@ -4611,6 +4611,14 @@
         },
         {
           "doc": "TODO\n",
+          "name": "get_texture_binding_view_dimension",
+          "returns": {
+            "doc": "TODO\n",
+            "type": "enum.texture_view_dimension"
+          }
+        },
+        {
+          "doc": "TODO\n",
           "name": "get_format",
           "returns": {
             "doc": "TODO\n",

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -5356,6 +5356,13 @@ objects:
           doc: |
             TODO
           type: enum.texture_dimension
+      - name: get_texture_binding_view_dimension
+        doc: |
+          TODO
+        returns:
+          doc: |
+            TODO
+          type: enum.texture_view_dimension
       - name: get_format
         doc: |
           TODO


### PR DESCRIPTION
This is was recently added to the WebGPU spec for compatibility mode https://www.w3.org/TR/webgpu/#dom-gputexture-texturebindingviewdimension