### PR TITLE
Add missing setImmediates method

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -5184,7 +5184,7 @@ typedef void (*WGPUProcComputePassEncoderSetBindGroup)(WGPUComputePassEncoder co
  * Proc pointer type for @ref wgpuComputePassEncoderSetImmediates:
  * > @copydoc wgpuComputePassEncoderSetImmediates
  */
-typedef void (*WGPUProcComputePassEncoderSetImmediates)(WGPUComputePassEncoder computePassEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcComputePassEncoderSetImmediates)(WGPUComputePassEncoder computePassEncoder, uint32_t offset, void const * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuComputePassEncoderSetLabel:
  * > @copydoc wgpuComputePassEncoderSetLabel
@@ -5572,7 +5572,7 @@ typedef void (*WGPUProcRenderBundleEncoderSetBindGroup)(WGPURenderBundleEncoder 
  * Proc pointer type for @ref wgpuRenderBundleEncoderSetImmediates:
  * > @copydoc wgpuRenderBundleEncoderSetImmediates
  */
-typedef void (*WGPUProcRenderBundleEncoderSetImmediates)(WGPURenderBundleEncoder renderBundleEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcRenderBundleEncoderSetImmediates)(WGPURenderBundleEncoder renderBundleEncoder, uint32_t offset, void const * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderBundleEncoderSetIndexBuffer:
  * > @copydoc wgpuRenderBundleEncoderSetIndexBuffer
@@ -5674,7 +5674,7 @@ typedef void (*WGPUProcRenderPassEncoderSetBlendConstant)(WGPURenderPassEncoder 
  * Proc pointer type for @ref wgpuRenderPassEncoderSetImmediates:
  * > @copydoc wgpuRenderPassEncoderSetImmediates
  */
-typedef void (*WGPUProcRenderPassEncoderSetImmediates)(WGPURenderPassEncoder renderPassEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcRenderPassEncoderSetImmediates)(WGPURenderPassEncoder renderPassEncoder, uint32_t offset, void const * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderPassEncoderSetIndexBuffer:
  * > @copydoc wgpuRenderPassEncoderSetIndexBuffer
@@ -6228,7 +6228,7 @@ WGPU_EXPORT void wgpuComputePassEncoderInsertDebugMarker(WGPUComputePassEncoder 
 WGPU_EXPORT void wgpuComputePassEncoderPopDebugGroup(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderPushDebugGroup(WGPUComputePassEncoder computePassEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderSetBindGroup(WGPUComputePassEncoder computePassEncoder, uint32_t groupIndex, WGPU_NULLABLE WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuComputePassEncoderSetImmediates(WGPUComputePassEncoder computePassEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuComputePassEncoderSetImmediates(WGPUComputePassEncoder computePassEncoder, uint32_t offset, void const * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderSetLabel(WGPUComputePassEncoder computePassEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderSetPipeline(WGPUComputePassEncoder computePassEncoder, WGPUComputePipeline pipeline) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderAddRef(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -6504,7 +6504,7 @@ WGPU_EXPORT void wgpuRenderBundleEncoderInsertDebugMarker(WGPURenderBundleEncode
 WGPU_EXPORT void wgpuRenderBundleEncoderPopDebugGroup(WGPURenderBundleEncoder renderBundleEncoder) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderPushDebugGroup(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetBindGroup(WGPURenderBundleEncoder renderBundleEncoder, uint32_t groupIndex, WGPU_NULLABLE WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuRenderBundleEncoderSetImmediates(WGPURenderBundleEncoder renderBundleEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderBundleEncoderSetImmediates(WGPURenderBundleEncoder renderBundleEncoder, uint32_t offset, void const * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetIndexBuffer(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetLabel(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetPipeline(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderPipeline pipeline) WGPU_FUNCTION_ATTRIBUTE;
@@ -6537,7 +6537,7 @@ WGPU_EXPORT void wgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder renderP
  * The RGBA blend constant. Represents an `f32` color using @ref DoubleAsSupertype.
  */
 WGPU_EXPORT void wgpuRenderPassEncoderSetBlendConstant(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuRenderPassEncoderSetImmediates(WGPURenderPassEncoder renderPassEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderPassEncoderSetImmediates(WGPURenderPassEncoder renderPassEncoder, uint32_t offset, void const * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetIndexBuffer(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetLabel(WGPURenderPassEncoder renderPassEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetPipeline(WGPURenderPassEncoder renderPassEncoder, WGPURenderPipeline pipeline) WGPU_FUNCTION_ATTRIBUTE;

--- a/webgpu.h
+++ b/webgpu.h
@@ -5181,6 +5181,11 @@ typedef void (*WGPUProcComputePassEncoderPushDebugGroup)(WGPUComputePassEncoder 
  */
 typedef void (*WGPUProcComputePassEncoderSetBindGroup)(WGPUComputePassEncoder computePassEncoder, uint32_t groupIndex, WGPU_NULLABLE WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) WGPU_FUNCTION_ATTRIBUTE;
 /**
+ * Proc pointer type for @ref wgpuComputePassEncoderSetImmediates:
+ * > @copydoc wgpuComputePassEncoderSetImmediates
+ */
+typedef void (*WGPUProcComputePassEncoderSetImmediates)(WGPUComputePassEncoder computePassEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
+/**
  * Proc pointer type for @ref wgpuComputePassEncoderSetLabel:
  * > @copydoc wgpuComputePassEncoderSetLabel
  */
@@ -5564,6 +5569,11 @@ typedef void (*WGPUProcRenderBundleEncoderPushDebugGroup)(WGPURenderBundleEncode
  */
 typedef void (*WGPUProcRenderBundleEncoderSetBindGroup)(WGPURenderBundleEncoder renderBundleEncoder, uint32_t groupIndex, WGPU_NULLABLE WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) WGPU_FUNCTION_ATTRIBUTE;
 /**
+ * Proc pointer type for @ref wgpuRenderBundleEncoderSetImmediates:
+ * > @copydoc wgpuRenderBundleEncoderSetImmediates
+ */
+typedef void (*WGPUProcRenderBundleEncoderSetImmediates)(WGPURenderBundleEncoder renderBundleEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
+/**
  * Proc pointer type for @ref wgpuRenderBundleEncoderSetIndexBuffer:
  * > @copydoc wgpuRenderBundleEncoderSetIndexBuffer
  */
@@ -5660,6 +5670,11 @@ typedef void (*WGPUProcRenderPassEncoderSetBindGroup)(WGPURenderPassEncoder rend
  * > @copydoc wgpuRenderPassEncoderSetBlendConstant
  */
 typedef void (*WGPUProcRenderPassEncoderSetBlendConstant)(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color) WGPU_FUNCTION_ATTRIBUTE;
+/**
+ * Proc pointer type for @ref wgpuRenderPassEncoderSetImmediates:
+ * > @copydoc wgpuRenderPassEncoderSetImmediates
+ */
+typedef void (*WGPUProcRenderPassEncoderSetImmediates)(WGPURenderPassEncoder renderPassEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
 /**
  * Proc pointer type for @ref wgpuRenderPassEncoderSetIndexBuffer:
  * > @copydoc wgpuRenderPassEncoderSetIndexBuffer
@@ -6213,6 +6228,7 @@ WGPU_EXPORT void wgpuComputePassEncoderInsertDebugMarker(WGPUComputePassEncoder 
 WGPU_EXPORT void wgpuComputePassEncoderPopDebugGroup(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderPushDebugGroup(WGPUComputePassEncoder computePassEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderSetBindGroup(WGPUComputePassEncoder computePassEncoder, uint32_t groupIndex, WGPU_NULLABLE WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuComputePassEncoderSetImmediates(WGPUComputePassEncoder computePassEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderSetLabel(WGPUComputePassEncoder computePassEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderSetPipeline(WGPUComputePassEncoder computePassEncoder, WGPUComputePipeline pipeline) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuComputePassEncoderAddRef(WGPUComputePassEncoder computePassEncoder) WGPU_FUNCTION_ATTRIBUTE;
@@ -6488,6 +6504,7 @@ WGPU_EXPORT void wgpuRenderBundleEncoderInsertDebugMarker(WGPURenderBundleEncode
 WGPU_EXPORT void wgpuRenderBundleEncoderPopDebugGroup(WGPURenderBundleEncoder renderBundleEncoder) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderPushDebugGroup(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView groupLabel) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetBindGroup(WGPURenderBundleEncoder renderBundleEncoder, uint32_t groupIndex, WGPU_NULLABLE WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderBundleEncoderSetImmediates(WGPURenderBundleEncoder renderBundleEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetIndexBuffer(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetLabel(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderBundleEncoderSetPipeline(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderPipeline pipeline) WGPU_FUNCTION_ATTRIBUTE;
@@ -6520,6 +6537,7 @@ WGPU_EXPORT void wgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder renderP
  * The RGBA blend constant. Represents an `f32` color using @ref DoubleAsSupertype.
  */
 WGPU_EXPORT void wgpuRenderPassEncoderSetBlendConstant(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuRenderPassEncoderSetImmediates(WGPURenderPassEncoder renderPassEncoder, uint32_t rangeOffset, void const * data, WGPU_NULLABLE uint64_t dataOffset, WGPU_NULLABLE uint64_t dataSize) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetIndexBuffer(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetLabel(WGPURenderPassEncoder renderPassEncoder, WGPUStringView label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuRenderPassEncoderSetPipeline(WGPURenderPassEncoder renderPassEncoder, WGPURenderPipeline pipeline) WGPU_FUNCTION_ATTRIBUTE;

--- a/webgpu.json
+++ b/webgpu.json
@@ -3127,7 +3127,7 @@
           "args": [
             {
               "doc": "TODO\n",
-              "name": "range_offset",
+              "name": "offset",
               "type": "uint32"
             },
             {
@@ -3138,15 +3138,8 @@
             },
             {
               "doc": "TODO\n",
-              "name": "data_offset",
-              "optional": true,
-              "type": "uint64"
-            },
-            {
-              "doc": "TODO\n",
-              "name": "data_size",
-              "optional": true,
-              "type": "uint64"
+              "name": "size",
+              "type": "usize"
             }
           ],
           "doc": "TODO\n",
@@ -3908,7 +3901,7 @@
           "args": [
             {
               "doc": "TODO\n",
-              "name": "range_offset",
+              "name": "offset",
               "type": "uint32"
             },
             {
@@ -3919,15 +3912,8 @@
             },
             {
               "doc": "TODO\n",
-              "name": "data_offset",
-              "optional": true,
-              "type": "uint64"
-            },
-            {
-              "doc": "TODO\n",
-              "name": "data_size",
-              "optional": true,
-              "type": "uint64"
+              "name": "size",
+              "type": "usize"
             }
           ],
           "doc": "TODO\n",
@@ -4174,7 +4160,7 @@
           "args": [
             {
               "doc": "TODO\n",
-              "name": "range_offset",
+              "name": "offset",
               "type": "uint32"
             },
             {
@@ -4185,15 +4171,8 @@
             },
             {
               "doc": "TODO\n",
-              "name": "data_offset",
-              "optional": true,
-              "type": "uint64"
-            },
-            {
-              "doc": "TODO\n",
-              "name": "data_size",
-              "optional": true,
-              "type": "uint64"
+              "name": "size",
+              "type": "usize"
             }
           ],
           "doc": "TODO\n",

--- a/webgpu.json
+++ b/webgpu.json
@@ -3127,6 +3127,35 @@
           "args": [
             {
               "doc": "TODO\n",
+              "name": "range_offset",
+              "type": "uint32"
+            },
+            {
+              "doc": "TODO\n",
+              "name": "data",
+              "pointer": "immutable",
+              "type": "c_void"
+            },
+            {
+              "doc": "TODO\n",
+              "name": "data_offset",
+              "optional": true,
+              "type": "uint64"
+            },
+            {
+              "doc": "TODO\n",
+              "name": "data_size",
+              "optional": true,
+              "type": "uint64"
+            }
+          ],
+          "doc": "TODO\n",
+          "name": "set_immediates"
+        },
+        {
+          "args": [
+            {
+              "doc": "TODO\n",
               "name": "workgroupCountX",
               "type": "uint32"
             },
@@ -3879,6 +3908,35 @@
           "args": [
             {
               "doc": "TODO\n",
+              "name": "range_offset",
+              "type": "uint32"
+            },
+            {
+              "doc": "TODO\n",
+              "name": "data",
+              "pointer": "immutable",
+              "type": "c_void"
+            },
+            {
+              "doc": "TODO\n",
+              "name": "data_offset",
+              "optional": true,
+              "type": "uint64"
+            },
+            {
+              "doc": "TODO\n",
+              "name": "data_size",
+              "optional": true,
+              "type": "uint64"
+            }
+          ],
+          "doc": "TODO\n",
+          "name": "set_immediates"
+        },
+        {
+          "args": [
+            {
+              "doc": "TODO\n",
               "name": "vertex_count",
               "type": "uint32"
             },
@@ -4111,6 +4169,35 @@
           ],
           "doc": "TODO\n",
           "name": "set_bind_group"
+        },
+        {
+          "args": [
+            {
+              "doc": "TODO\n",
+              "name": "range_offset",
+              "type": "uint32"
+            },
+            {
+              "doc": "TODO\n",
+              "name": "data",
+              "pointer": "immutable",
+              "type": "c_void"
+            },
+            {
+              "doc": "TODO\n",
+              "name": "data_offset",
+              "optional": true,
+              "type": "uint64"
+            },
+            {
+              "doc": "TODO\n",
+              "name": "data_size",
+              "optional": true,
+              "type": "uint64"
+            }
+          ],
+          "doc": "TODO\n",
+          "name": "set_immediates"
         },
         {
           "args": [

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -4233,6 +4233,29 @@ objects:
               TODO
             type: array<uint32>
             pointer: immutable
+      - name: set_immediates
+        doc: |
+          TODO
+        args:
+          - name: range_offset
+            doc: |
+              TODO
+            type: uint32
+          - name: data
+            doc: |
+              TODO
+            type: c_void
+            pointer: immutable
+          - name: data_offset
+            doc: |
+              TODO
+            type: uint64
+            optional: true
+          - name: data_size
+            doc: |
+              TODO
+            type: uint64
+            optional: true
       - name: dispatch_workgroups
         doc: |
           TODO
@@ -4829,6 +4852,29 @@ objects:
               TODO
             type: array<uint32>
             pointer: immutable
+      - name: set_immediates
+        doc: |
+          TODO
+        args:
+          - name: range_offset
+            doc: |
+              TODO
+            type: uint32
+          - name: data
+            doc: |
+              TODO
+            type: c_void
+            pointer: immutable
+          - name: data_offset
+            doc: |
+              TODO
+            type: uint64
+            optional: true
+          - name: data_size
+            doc: |
+              TODO
+            type: uint64
+            optional: true
       - name: draw
         doc: |
           TODO
@@ -5010,6 +5056,29 @@ objects:
               TODO
             type: array<uint32>
             pointer: immutable
+      - name: set_immediates
+        doc: |
+          TODO
+        args:
+          - name: range_offset
+            doc: |
+              TODO
+            type: uint32
+          - name: data
+            doc: |
+              TODO
+            type: c_void
+            pointer: immutable
+          - name: data_offset
+            doc: |
+              TODO
+            type: uint64
+            optional: true
+          - name: data_size
+            doc: |
+              TODO
+            type: uint64
+            optional: true
       - name: draw
         doc: |
           TODO

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -4237,7 +4237,7 @@ objects:
         doc: |
           TODO
         args:
-          - name: range_offset
+          - name: offset
             doc: |
               TODO
             type: uint32
@@ -4246,16 +4246,10 @@ objects:
               TODO
             type: c_void
             pointer: immutable
-          - name: data_offset
+          - name: size
             doc: |
               TODO
-            type: uint64
-            optional: true
-          - name: data_size
-            doc: |
-              TODO
-            type: uint64
-            optional: true
+            type: usize
       - name: dispatch_workgroups
         doc: |
           TODO
@@ -4856,7 +4850,7 @@ objects:
         doc: |
           TODO
         args:
-          - name: range_offset
+          - name: offset
             doc: |
               TODO
             type: uint32
@@ -4865,16 +4859,10 @@ objects:
               TODO
             type: c_void
             pointer: immutable
-          - name: data_offset
+          - name: size
             doc: |
               TODO
-            type: uint64
-            optional: true
-          - name: data_size
-            doc: |
-              TODO
-            type: uint64
-            optional: true
+            type: usize
       - name: draw
         doc: |
           TODO
@@ -5060,7 +5048,7 @@ objects:
         doc: |
           TODO
         args:
-          - name: range_offset
+          - name: offset
             doc: |
               TODO
             type: uint32
@@ -5069,16 +5057,10 @@ objects:
               TODO
             type: c_void
             pointer: immutable
-          - name: data_offset
+          - name: size
             doc: |
               TODO
-            type: uint64
-            optional: true
-          - name: data_size
-            doc: |
-              TODO
-            type: uint64
-            optional: true
+            type: usize
       - name: draw
         doc: |
           TODO


### PR DESCRIPTION
This PR adds missing the `setImmediates` method as described in https://github.com/gpuweb/gpuweb/pull/5423/