### PR TITLE
Add "subgroup-size-control" feature

### DIFF
--- a/webgpu.h
+++ b/webgpu.h
@@ -657,11 +657,11 @@ typedef enum WGPUFeatureName {
     WGPUFeatureName_ClipDistances = 0x00000010,
     WGPUFeatureName_DualSourceBlending = 0x00000011,
     WGPUFeatureName_Subgroups = 0x00000012,
-    WGPUFeatureName_SubgroupSizeControl = 0x00000013,
-    WGPUFeatureName_TextureFormatsTier1 = 0x00000014,
-    WGPUFeatureName_TextureFormatsTier2 = 0x00000015,
-    WGPUFeatureName_PrimitiveIndex = 0x00000016,
-    WGPUFeatureName_TextureComponentSwizzle = 0x00000017,
+    WGPUFeatureName_TextureFormatsTier1 = 0x00000013,
+    WGPUFeatureName_TextureFormatsTier2 = 0x00000014,
+    WGPUFeatureName_PrimitiveIndex = 0x00000015,
+    WGPUFeatureName_TextureComponentSwizzle = 0x00000016,
+    WGPUFeatureName_SubgroupSizeControl = 0x00000017,
     WGPUFeatureName_Force32 = 0x7FFFFFFF
 } WGPUFeatureName WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.h
+++ b/webgpu.h
@@ -657,10 +657,11 @@ typedef enum WGPUFeatureName {
     WGPUFeatureName_ClipDistances = 0x00000010,
     WGPUFeatureName_DualSourceBlending = 0x00000011,
     WGPUFeatureName_Subgroups = 0x00000012,
-    WGPUFeatureName_TextureFormatsTier1 = 0x00000013,
-    WGPUFeatureName_TextureFormatsTier2 = 0x00000014,
-    WGPUFeatureName_PrimitiveIndex = 0x00000015,
-    WGPUFeatureName_TextureComponentSwizzle = 0x00000016,
+    WGPUFeatureName_SubgroupSizeControl = 0x00000013,
+    WGPUFeatureName_TextureFormatsTier1 = 0x00000014,
+    WGPUFeatureName_TextureFormatsTier2 = 0x00000015,
+    WGPUFeatureName_PrimitiveIndex = 0x00000016,
+    WGPUFeatureName_TextureComponentSwizzle = 0x00000017,
     WGPUFeatureName_Force32 = 0x7FFFFFFF
 } WGPUFeatureName WGPU_ENUM_ATTRIBUTE;
 

--- a/webgpu.json
+++ b/webgpu.json
@@ -1053,6 +1053,10 @@
         },
         {
           "doc": "TODO\n",
+          "name": "subgroup_size_control"
+        },
+        {
+          "doc": "TODO\n",
           "name": "texture_formats_tier_1"
         },
         {

--- a/webgpu.json
+++ b/webgpu.json
@@ -1053,10 +1053,6 @@
         },
         {
           "doc": "TODO\n",
-          "name": "subgroup_size_control"
-        },
-        {
-          "doc": "TODO\n",
           "name": "texture_formats_tier_1"
         },
         {
@@ -1070,6 +1066,10 @@
         {
           "doc": "TODO\n",
           "name": "texture_component_swizzle"
+        },
+        {
+          "doc": "TODO\n",
+          "name": "subgroup_size_control"
         }
       ],
       "name": "feature_name"

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -520,9 +520,6 @@ enums:
       - name: subgroups
         doc: |
           TODO
-      - name: subgroup_size_control
-        doc: |
-          TODO
       - name: texture_formats_tier_1
         doc: |
           TODO
@@ -533,6 +530,9 @@ enums:
         doc: |
           TODO
       - name: texture_component_swizzle
+        doc: |
+          TODO
+      - name: subgroup_size_control
         doc: |
           TODO
   - name: filter_mode

--- a/webgpu.yml
+++ b/webgpu.yml
@@ -520,6 +520,9 @@ enums:
       - name: subgroups
         doc: |
           TODO
+      - name: subgroup_size_control
+        doc: |
+          TODO
       - name: texture_formats_tier_1
         doc: |
           TODO


### PR DESCRIPTION
This patch adds the "subgroup-size-control" feature added in gpuweb/gpuweb#5578.